### PR TITLE
feat: add evidence-anchored explainability, cached evaluation, and session review UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ VocalMind is a modular AI ecosystem integrating speech processing (ASR, Diarizat
 | **Emotion**  | Transformers, FastAPI | Speech emotion recognition microservice. |
 | **RAG**      | LlamaIndex, Qdrant, Groq, Ollama | Retrieval-Augmented Generation for knowledge queries. |
 | **Ingestion**| LlamaIndex | Automated pipeline for RAG document ingestion. |
+| **Explainability** | FastAPI, React, LLM/NLI attribution | Evidence-anchored layer that links triggers and compliance verdicts to transcript spans and retrieved policy/SOP evidence. |
 | **Research** | Jupyter | Reference experiments for speech pipelines and voice generation. |
 
 ---
@@ -133,6 +134,13 @@ make clean            # Remove caches and build artifacts
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+## Key Docs
+
+- [Documentation Index](docs/README.md)
+- [Evidence-Anchored Explainability Layer](docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md)
+- [LLM Trigger Feature Guide](docs/llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md)
+- [RAG Overview](docs/rag/RAG_OVERVIEW.md)
 
 ---
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -35,3 +35,9 @@ uv run uvicorn main:app --reload
   ```bash
   uv run pytest
   ```
+
+## Related Documentation
+
+- `docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md`
+- `docs/llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md`
+- `docs/rag/RAG_OVERVIEW.md`

--- a/backend/app/api/routes/agents.py
+++ b/backend/app/api/routes/agents.py
@@ -74,10 +74,10 @@ async def get_agent_profile(agent_id: UUID, session: SessionDep, current_user: C
     stats = scores_result.first()
 
     total_calls = stats.total_calls if stats and stats.total_calls else 0
-    avg_overall = round(stats.avg_overall * 10, 0) if stats and stats.avg_overall else 0
-    avg_empathy = round(stats.avg_empathy * 10, 0) if stats and stats.avg_empathy else 0
-    avg_policy = round(stats.avg_policy * 10, 0) if stats and stats.avg_policy else 0
-    avg_resolution = round(stats.avg_resolution * 10, 0) if stats and stats.avg_resolution else 0
+    avg_overall = round(stats.avg_overall * 100, 0) if stats and stats.avg_overall else 0
+    avg_empathy = round(stats.avg_empathy * 100, 0) if stats and stats.avg_empathy else 0
+    avg_policy = round(stats.avg_policy * 100, 0) if stats and stats.avg_policy else 0
+    avg_resolution = round(stats.avg_resolution * 100, 0) if stats and stats.avg_resolution else 0
     avg_response = f"{stats.avg_response:.1f}s" if stats and stats.avg_response else "N/A"
 
     # 3. Resolution rate
@@ -110,7 +110,7 @@ async def get_agent_profile(agent_id: UUID, session: SessionDep, current_user: C
             "id": str(r.id),
             "date": r.interaction_date.strftime("%Y-%m-%d") if r.interaction_date else "",
             "time": r.interaction_date.strftime("%I:%M %p") if r.interaction_date else "",
-            "score": round(r.overall_score * 10, 0) if r.overall_score else 0,
+            "score": round(r.overall_score * 100, 0) if r.overall_score else 0,
             "duration": f"{r.duration_seconds // 60}:{r.duration_seconds % 60:02d}",
             "language": r.language_detected or "Unknown",
             "resolved": r.was_resolved or False,
@@ -136,7 +136,7 @@ async def get_agent_profile(agent_id: UUID, session: SessionDep, current_user: C
     weekly_trend = [
         {
             "day": day_names[(int(r.dow) - 1) % 7],
-            "score": round(r.avg_score * 10, 0) if r.avg_score else 0,
+            "score": round(r.avg_score * 100, 0) if r.avg_score else 0,
         }
         for r in weekly_result.all()
     ]

--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -189,10 +189,10 @@ async def get_dashboard_stats(session: SessionDep, current_user: CurrentUser):
             return [
                 {
                     "name": row.name,
-                    "empathy": round(row.empathy * 10, 0) if row.empathy else 0,
-                    "policy": round(row.policy * 10, 0) if row.policy else 0,
-                    "resolution": round(row.resolution * 10, 0) if row.resolution else 0,
-                    "overallScore": round(row.overall * 10, 0) if row.overall else 0,
+                    "empathy": round(row.empathy * 100, 0) if row.empathy else 0,
+                    "policy": round(row.policy * 100, 0) if row.policy else 0,
+                    "resolution": round(row.resolution * 100, 0) if row.resolution else 0,
+                    "overallScore": round(row.overall * 100, 0) if row.overall else 0,
                     "trend": "up",
                 }
                 for row in agent_perf_result.all()
@@ -243,10 +243,10 @@ async def get_dashboard_stats(session: SessionDep, current_user: CurrentUser):
                     "time": row.interaction_date.strftime("%I:%M %p") if row.interaction_date else "",
                     "duration": f"{mins}:{secs:02d}",
                     "language": row.language_detected or "Unknown",
-                    "overallScore": round(row.overall_score * 10, 0) if row.overall_score else 0,
-                    "empathyScore": round(row.empathy_score * 10, 0) if row.empathy_score else 0,
-                    "policyScore": round(row.policy_score * 10, 0) if row.policy_score else 0,
-                    "resolutionScore": round(row.resolution_score * 10, 0) if row.resolution_score else 0,
+                    "overallScore": round(row.overall_score * 100, 0) if row.overall_score else 0,
+                    "empathyScore": round(row.empathy_score * 100, 0) if row.empathy_score else 0,
+                    "policyScore": round(row.policy_score * 100, 0) if row.policy_score else 0,
+                    "resolutionScore": round(row.resolution_score * 100, 0) if row.resolution_score else 0,
                     "resolved": row.was_resolved or False,
                     "hasViolation": row.viol_count > 0,
                     "hasOverlap": row.has_overlap,

--- a/backend/app/api/routes/interactions.py
+++ b/backend/app/api/routes/interactions.py
@@ -5,7 +5,9 @@ from collections import Counter
 from datetime import datetime, timezone
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict
 from sqlmodel import select, func
+from typing import Any, Literal
 from uuid import UUID
 import httpx
 import io
@@ -36,6 +38,236 @@ from app.models.user import User as UserModel
 from app.models.enums import ProcessingStatus, UserRole
 
 router = APIRouter()
+
+
+class APIModel(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+class ExplainabilitySpanResponse(APIModel):
+    utteranceIndex: int | None = None
+    speaker: str | None = None
+    quote: str
+    timestamp: str | None = None
+    startSeconds: float | None = None
+    endSeconds: float | None = None
+
+
+class ExplainabilityPolicyReferenceResponse(APIModel):
+    source: Literal["policy", "sop"]
+    reference: str
+    clause: str
+    version: str | None = None
+    category: str | None = None
+    provenance: str | None = None
+
+
+class TriggerAttributionResponse(APIModel):
+    attributionId: str
+    family: Literal["emotion", "sop", "policy"]
+    triggerType: str
+    title: str
+    verdict: str
+    confidence: float | None = None
+    evidenceSpan: ExplainabilitySpanResponse | None = None
+    policyReference: ExplainabilityPolicyReferenceResponse | None = None
+    reasoning: str
+    evidenceChain: list[str]
+    supportingQuotes: list[str]
+
+
+class ClaimProvenanceResponse(APIModel):
+    claimId: str
+    claimText: str
+    claimSpan: ExplainabilitySpanResponse | None = None
+    retrievedPolicy: ExplainabilityPolicyReferenceResponse | None = None
+    semanticSimilarity: float | None = None
+    nliVerdict: str
+    confidence: float | None = None
+    reasoning: str
+    provenance: str
+    supportingQuotes: list[str]
+
+
+class EvidenceAnchoredExplainabilityResponse(APIModel):
+    triggerAttributions: list[TriggerAttributionResponse] = []
+    claimProvenance: list[ClaimProvenanceResponse] = []
+
+
+class LLMEvidenceCitationResponse(APIModel):
+    source: str
+    speaker: str | None = None
+    quote: str
+    utteranceIndex: int | None = None
+
+
+class LLMEmotionShiftResponse(APIModel):
+    isDissonanceDetected: bool
+    dissonanceType: str
+    rootCause: str
+    currentCustomerEmotion: str | None = None
+    currentEmotionReasoning: str | None = None
+    counterfactualCorrection: str
+    evidenceQuotes: list[str]
+    citations: list[LLMEvidenceCitationResponse]
+    insufficientEvidence: bool | None = None
+    confidenceScore: float | None = None
+
+
+class LLMProcessAdherenceResponse(APIModel):
+    detectedTopic: str
+    isResolved: bool
+    efficiencyScore: int
+    justification: str
+    missingSopSteps: list[str]
+    evidenceQuotes: list[str]
+    citations: list[LLMEvidenceCitationResponse]
+    insufficientEvidence: bool | None = None
+    confidenceScore: float | None = None
+
+
+class LLMNliPolicyResponse(APIModel):
+    nliCategory: str
+    justification: str
+    evidenceQuotes: list[str]
+    citations: list[LLMEvidenceCitationResponse]
+    policyVersion: str | None = None
+    policyEffectiveAt: str | None = None
+    policyCategory: str | None = None
+    conflictResolutionApplied: bool | None = None
+    insufficientEvidence: bool | None = None
+    confidenceScore: float | None = None
+    policyAlignmentScore: float | None = None
+
+
+class LLMDerivedSignalsResponse(APIModel):
+    customerText: str
+    acousticEmotion: str
+    fusedEmotion: str
+    agentStatement: str
+
+
+class EmotionTriggerReportResponse(APIModel):
+    available: bool
+    error: str | None = None
+    orgFilter: str | None = None
+    forcedRerun: bool | None = None
+    interactionId: str | None = None
+    emotionShift: LLMEmotionShiftResponse | None = None
+    explainability: EvidenceAnchoredExplainabilityResponse | None = None
+    derived: LLMDerivedSignalsResponse | None = None
+
+
+class RagComplianceReportResponse(APIModel):
+    available: bool
+    error: str | None = None
+    orgFilter: str | None = None
+    forcedRerun: bool | None = None
+    interactionId: str | None = None
+    processAdherence: LLMProcessAdherenceResponse | None = None
+    nliPolicy: LLMNliPolicyResponse | None = None
+    explainability: EvidenceAnchoredExplainabilityResponse | None = None
+    policyViolations: list["PolicyViolationResponse"] | None = None
+
+
+class LLMTriggerReportResponse(APIModel):
+    available: bool
+    error: str | None = None
+    orgFilter: str | None = None
+    forcedRerun: bool | None = None
+    interactionId: str | None = None
+    emotionShift: LLMEmotionShiftResponse | None = None
+    processAdherence: LLMProcessAdherenceResponse | None = None
+    nliPolicy: LLMNliPolicyResponse | None = None
+    explainability: EvidenceAnchoredExplainabilityResponse | None = None
+    derived: LLMDerivedSignalsResponse | None = None
+
+
+class InteractionDetailSummaryResponse(APIModel):
+    id: str
+    agentName: str
+    agentId: str
+    date: str
+    time: str
+    duration: str
+    language: str
+    overallScore: float
+    empathyScore: float
+    policyScore: float
+    resolutionScore: float
+    resolved: bool
+    hasViolation: bool
+    hasOverlap: bool
+    responseTime: str
+    status: str
+    audioFilePath: str | None = None
+
+
+class UtteranceResponse(APIModel):
+    id: str
+    interactionId: str
+    speaker: str
+    sequenceIndex: int | None = None
+    text: str
+    startTime: float
+    endTime: float
+    timestamp: str
+    emotion: str
+    confidence: float
+    textEmotion: str | None = None
+    textConfidence: float | None = None
+    fusedEmotion: str | None = None
+    fusedConfidence: float | None = None
+    fusionModel: str | None = None
+
+
+class EmotionEventResponse(APIModel):
+    id: str
+    interactionId: str
+    previousEmotion: str
+    newEmotion: str
+    fromEmotion: str
+    toEmotion: str
+    jumpToSeconds: float
+    timestamp: str
+    confidenceScore: float
+    delta: float
+    speaker: str
+    llmJustification: str
+    justification: str
+
+
+class PolicyViolationResponse(APIModel):
+    id: str
+    interactionId: str
+    policyName: str
+    policyTitle: str
+    category: str
+    description: str
+    reasoning: str
+    severity: str
+    score: float
+
+
+class EmotionComparisonResponse(APIModel):
+    totalUtterances: int
+    distributions: dict[str, Any]
+    quality: dict[str, Any]
+    evidence: dict[str, Any] | None = None
+
+
+class InteractionDetailResponse(APIModel):
+    interaction: InteractionDetailSummaryResponse
+    utterances: list[UtteranceResponse]
+    emotionComparison: EmotionComparisonResponse
+    ragCompliance: RagComplianceReportResponse | None = None
+    emotionTriggers: EmotionTriggerReportResponse | None = None
+    llmTriggers: LLMTriggerReportResponse | None = None
+    emotionEvents: list[EmotionEventResponse]
+    policyViolations: list[PolicyViolationResponse]
+
+
+RagComplianceReportResponse.model_rebuild()
 
 
 @router.post("")
@@ -321,6 +553,54 @@ def _map_emotion_trigger_report(report) -> dict:
             "utteranceIndex": citation.utterance_index,
         }
 
+    def _span_to_dict(span) -> dict | None:
+        if not span:
+            return None
+        return {
+            "utteranceIndex": span.utterance_index,
+            "speaker": span.speaker,
+            "quote": span.quote,
+            "timestamp": span.timestamp,
+            "startSeconds": span.start_seconds,
+            "endSeconds": span.end_seconds,
+        }
+
+    def _policy_reference_to_dict(reference) -> dict | None:
+        if not reference:
+            return None
+        return {
+            "source": reference.source,
+            "reference": reference.reference,
+            "clause": reference.clause,
+            "version": reference.version,
+            "category": reference.category,
+            "provenance": reference.provenance,
+        }
+
+    def _trigger_attribution_to_dict(attribution) -> dict:
+        return {
+            "attributionId": attribution.attribution_id,
+            "family": attribution.family,
+            "triggerType": attribution.trigger_type,
+            "title": attribution.title,
+            "verdict": attribution.verdict,
+            "confidence": attribution.confidence,
+            "evidenceSpan": _span_to_dict(attribution.evidence_span),
+            "policyReference": _policy_reference_to_dict(attribution.policy_reference),
+            "reasoning": attribution.reasoning,
+            "evidenceChain": attribution.evidence_chain,
+            "supportingQuotes": attribution.supporting_quotes,
+        }
+
+    explainability = {
+        "triggerAttributions": [
+            _trigger_attribution_to_dict(attribution)
+            for attribution in report.explainability.trigger_attributions
+            if attribution.family == "emotion"
+        ],
+        "claimProvenance": [],
+    }
+
     return {
         "available": True,
         "interactionId": str(report.interaction_id),
@@ -334,7 +614,9 @@ def _map_emotion_trigger_report(report) -> dict:
             "evidenceQuotes": report.emotion_shift.evidence_quotes,
             "citations": [_citation_to_dict(c) for c in report.emotion_shift.citations],
             "insufficientEvidence": report.emotion_shift.insufficient_evidence,
+            "confidenceScore": report.emotion_shift.confidence_score,
         },
+        "explainability": explainability,
         "derived": {
             "customerText": report.derived_customer_text,
             "acousticEmotion": report.derived_acoustic_emotion,
@@ -353,6 +635,71 @@ def _map_rag_compliance_report(report) -> dict:
             "utteranceIndex": citation.utterance_index,
         }
 
+    def _span_to_dict(span) -> dict | None:
+        if not span:
+            return None
+        return {
+            "utteranceIndex": span.utterance_index,
+            "speaker": span.speaker,
+            "quote": span.quote,
+            "timestamp": span.timestamp,
+            "startSeconds": span.start_seconds,
+            "endSeconds": span.end_seconds,
+        }
+
+    def _policy_reference_to_dict(reference) -> dict | None:
+        if not reference:
+            return None
+        return {
+            "source": reference.source,
+            "reference": reference.reference,
+            "clause": reference.clause,
+            "version": reference.version,
+            "category": reference.category,
+            "provenance": reference.provenance,
+        }
+
+    def _trigger_attribution_to_dict(attribution) -> dict:
+        return {
+            "attributionId": attribution.attribution_id,
+            "family": attribution.family,
+            "triggerType": attribution.trigger_type,
+            "title": attribution.title,
+            "verdict": attribution.verdict,
+            "confidence": attribution.confidence,
+            "evidenceSpan": _span_to_dict(attribution.evidence_span),
+            "policyReference": _policy_reference_to_dict(attribution.policy_reference),
+            "reasoning": attribution.reasoning,
+            "evidenceChain": attribution.evidence_chain,
+            "supportingQuotes": attribution.supporting_quotes,
+        }
+
+    def _claim_provenance_to_dict(provenance) -> dict:
+        return {
+            "claimId": provenance.claim_id,
+            "claimText": provenance.claim_text,
+            "claimSpan": _span_to_dict(provenance.claim_span),
+            "retrievedPolicy": _policy_reference_to_dict(provenance.retrieved_policy),
+            "semanticSimilarity": provenance.semantic_similarity,
+            "nliVerdict": provenance.nli_verdict,
+            "confidence": provenance.confidence,
+            "reasoning": provenance.reasoning,
+            "provenance": provenance.provenance,
+            "supportingQuotes": provenance.supporting_quotes,
+        }
+
+    explainability = {
+        "triggerAttributions": [
+            _trigger_attribution_to_dict(attribution)
+            for attribution in report.explainability.trigger_attributions
+            if attribution.family in {"sop", "policy"}
+        ],
+        "claimProvenance": [
+            _claim_provenance_to_dict(provenance)
+            for provenance in report.explainability.claim_provenance
+        ],
+    }
+
     return {
         "available": True,
         "interactionId": str(report.interaction_id),
@@ -365,6 +712,7 @@ def _map_rag_compliance_report(report) -> dict:
             "evidenceQuotes": report.process_adherence.evidence_quotes,
             "citations": [_citation_to_dict(c) for c in report.process_adherence.citations],
             "insufficientEvidence": report.process_adherence.insufficient_evidence,
+            "confidenceScore": report.process_adherence.confidence_score,
         },
         "nliPolicy": {
             "nliCategory": report.nli_policy.nli_category,
@@ -376,7 +724,10 @@ def _map_rag_compliance_report(report) -> dict:
             "policyCategory": report.nli_policy.policy_category,
             "conflictResolutionApplied": report.nli_policy.conflict_resolution_applied,
             "insufficientEvidence": report.nli_policy.insufficient_evidence,
+            "confidenceScore": report.nli_policy.confidence_score,
+            "policyAlignmentScore": report.nli_policy.policy_alignment_score,
         },
+        "explainability": explainability,
     }
 
 
@@ -390,6 +741,13 @@ def _map_llm_trigger_report(report) -> dict:
         "emotionShift": emotion_payload["emotionShift"],
         "processAdherence": rag_payload["processAdherence"],
         "nliPolicy": rag_payload["nliPolicy"],
+        "explainability": {
+            "triggerAttributions": [
+                *emotion_payload["explainability"]["triggerAttributions"],
+                *rag_payload["explainability"]["triggerAttributions"],
+            ],
+            "claimProvenance": rag_payload["explainability"]["claimProvenance"],
+        },
         "derived": emotion_payload["derived"],
     }
 
@@ -468,10 +826,10 @@ async def list_interactions(session: SessionDep, current_user: CurrentUser):
             "time": row.interaction_date.strftime("%I:%M %p") if row.interaction_date else "",
             "duration": f"{mins}:{secs:02d}",
             "language": row.language_detected or "Unknown",
-            "overallScore": round(row.overall_score * 10, 0) if row.overall_score else 0,
-            "empathyScore": round(row.empathy_score * 10, 0) if row.empathy_score else 0,
-            "policyScore": round(row.policy_score * 10, 0) if row.policy_score else 0,
-            "resolutionScore": round(row.resolution_score * 10, 0) if row.resolution_score else 0,
+            "overallScore": round(row.overall_score * 100, 0) if row.overall_score else 0,
+            "empathyScore": round(row.empathy_score * 100, 0) if row.empathy_score else 0,
+            "policyScore": round(row.policy_score * 100, 0) if row.policy_score else 0,
+            "resolutionScore": round(row.resolution_score * 100, 0) if row.resolution_score else 0,
             "resolved": row.was_resolved or False,
             "hasViolation": row.viol_count > 0,
             "hasOverlap": row.has_overlap,
@@ -483,7 +841,7 @@ async def list_interactions(session: SessionDep, current_user: CurrentUser):
     return interactions
 
 
-@router.get("/{interaction_id}")
+@router.get("/{interaction_id}", response_model=InteractionDetailResponse)
 async def get_interaction_detail(
     interaction_id: UUID,
     session: SessionDep,
@@ -555,6 +913,7 @@ async def get_interaction_detail(
                 "id": str(u.id),
                 "interactionId": str(u.interaction_id),
                 "speaker": u.speaker_role.value if u.speaker_role else "unknown",
+                "sequenceIndex": u.sequence_index,
                 "text": u.text or "",
                 "startTime": u.start_time_seconds,
                 "endTime": u.end_time_seconds,
@@ -662,6 +1021,8 @@ async def get_interaction_detail(
                 session=session,
                 interaction_id=interaction_id,
                 org_filter=resolved_org_filter,
+                force_rerun=llm_force_rerun,
+                commit_cache=True,
             )
             emotion_triggers = _map_emotion_trigger_report(report)
             rag_compliance = _map_rag_compliance_report(report)
@@ -710,10 +1071,10 @@ async def get_interaction_detail(
             "time": row.interaction_date.strftime("%I:%M %p") if row.interaction_date else "",
             "duration": f"{mins}:{secs:02d}",
             "language": row.language_detected or "Unknown",
-            "overallScore": round(row.overall_score * 10, 0) if row.overall_score else 0,
-            "empathyScore": round(row.empathy_score * 10, 0) if row.empathy_score else 0,
-            "policyScore": round(row.policy_score * 10, 0) if row.policy_score else 0,
-            "resolutionScore": round(row.resolution_score * 10, 0) if row.resolution_score else 0,
+            "overallScore": round(row.overall_score * 100, 0) if row.overall_score else 0,
+            "empathyScore": round(row.empathy_score * 100, 0) if row.empathy_score else 0,
+            "policyScore": round(row.policy_score * 100, 0) if row.policy_score else 0,
+            "resolutionScore": round(row.resolution_score * 100, 0) if row.resolution_score else 0,
             "resolved": row.was_resolved or False,
             "hasViolation": len(policy_violations) > 0,
             "hasOverlap": row.has_overlap,

--- a/backend/app/api/routes/llm_trigger/router.py
+++ b/backend/app/api/routes/llm_trigger/router.py
@@ -57,6 +57,10 @@ class InteractionTriggerRequest(BaseModel):
         default=None,
         description="Optional org metadata filter used during Qdrant retrieval.",
     )
+    force_rerun: bool = Field(
+        default=False,
+        description="When true, ignore any saved report and recompute triggers.",
+    )
 
 
 @router.post(
@@ -114,6 +118,8 @@ async def run_interaction_trigger_endpoint(
             retrieved_sop_from_pinecone=payload.retrieved_sop_from_pinecone,
             ground_truth_policy=payload.ground_truth_policy,
             org_filter=payload.org_filter,
+            force_rerun=payload.force_rerun,
+            commit_cache=True,
         )
     except ValueError as exc:
         message = str(exc)

--- a/backend/app/api/routes/rag.py
+++ b/backend/app/api/routes/rag.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import importlib.util
 import os
 import sys
@@ -23,6 +23,7 @@ class RAGQueryResponse(BaseModel):
     response: str
     chunks: list[dict]
     timing: dict
+    retrieval_provenance: list[dict] = Field(default_factory=list)
 
 
 # Lazy initialize engine
@@ -54,10 +55,37 @@ def query_rag_endpoint(request: RAGQueryRequest):
             result = engine.query_compliance(text=request.query, org_filter=request.org_filter)
         else:
             result = engine.query_answer(question=request.query, org_filter=request.org_filter)
+        retrieval_provenance: list[dict] = []
+        for chunk in result.get("chunks", []):
+            metadata = chunk.get("metadata", {})
+            similarity = float(chunk.get("score", 0.0))
+            header_path = " > ".join(
+                str(metadata.get(key)).strip()
+                for key in ("Header 1", "Header 2", "Header 3")
+                if metadata.get(key)
+            )
+            reference = header_path or str(metadata.get("source_file") or metadata.get("doc_id") or "Retrieved chunk")
+            verdict = "supported" if similarity >= 0.82 else "neutral" if similarity >= 0.55 else "insufficient_evidence"
+            retrieval_provenance.append(
+                {
+                    "claim": request.query,
+                    "chunkRank": chunk.get("rank"),
+                    "semanticSimilarity": similarity,
+                    "verdict": verdict,
+                    "reference": reference,
+                    "excerpt": chunk.get("text", "")[:220],
+                    "provenance": {
+                        "docId": metadata.get("doc_id"),
+                        "sourceFile": metadata.get("source_file"),
+                        "headerPath": header_path or None,
+                    },
+                }
+            )
         return RAGQueryResponse(
             response=result["response"],
             chunks=result.get("chunks", []),
             timing=result.get("timing", {}),
+            retrieval_provenance=retrieval_provenance,
         )
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -30,7 +30,7 @@ async def create_db_and_tables():
         Organization, User, Interaction, Transcript,
         Utterance, EmotionEvent, InteractionScore,
         CompanyPolicy, OrganizationPolicy, PolicyCompliance,
-        EmotionFeedback, ComplianceFeedback,
+        EmotionFeedback, ComplianceFeedback, InteractionLLMTriggerCache,
     )
 
     async with engine.begin() as conn:

--- a/backend/app/core/interaction_processing.py
+++ b/backend/app/core/interaction_processing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
@@ -24,6 +25,7 @@ from app.models.emotion_event import EmotionEvent
 from app.models.enums import JobStage, JobStatus, ProcessingStatus, SpeakerRole
 from app.models.interaction import Interaction
 from app.models.interaction_score import InteractionScore
+from app.models.llm_trigger_cache import InteractionLLMTriggerCache
 from app.models.organization import Organization
 from app.models.policy import CompanyPolicy, OrganizationPolicy, PolicyCompliance
 from app.models.processing import ProcessingJob
@@ -57,6 +59,68 @@ def _storage_root() -> Path:
 def _sanitize_filename(filename: str) -> str:
     cleaned = Path(filename or "").name.strip()
     return cleaned or f"audio_{datetime.now(timezone.utc).timestamp():.0f}.wav"
+
+
+def _normalize_lookup_text(value: str | None) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (value or "").lower()).strip()
+
+
+async def _resolve_policy_record_for_report(
+    session: AsyncSession,
+    organization_id: UUID,
+    report,
+) -> CompanyPolicy | None:
+    policies_result = await session.exec(
+        select(CompanyPolicy)
+        .join(OrganizationPolicy, OrganizationPolicy.policy_id == CompanyPolicy.id)
+        .where(
+            OrganizationPolicy.organization_id == organization_id,
+            OrganizationPolicy.is_active.is_(True),
+            CompanyPolicy.is_active.is_(True),
+        )
+    )
+    policies = list(policies_result.all())
+    if not policies:
+        return None
+
+    policy_quotes = [
+        _normalize_lookup_text(citation.quote)
+        for citation in report.nli_policy.citations
+        if citation.source == "policy" and (citation.quote or "").strip()
+    ]
+    reference_hints: list[str] = []
+    for claim in report.explainability.claim_provenance:
+        if not claim.retrieved_policy:
+            continue
+        reference_hints.append(_normalize_lookup_text(claim.retrieved_policy.reference))
+        if claim.retrieved_policy.provenance:
+            reference_hints.append(_normalize_lookup_text(claim.retrieved_policy.provenance))
+
+    best_policy: CompanyPolicy | None = None
+    best_score = -1
+    for policy in policies:
+        title_norm = _normalize_lookup_text(policy.policy_title)
+        text_norm = _normalize_lookup_text(policy.policy_text)
+        title_tokens = set(title_norm.split())
+        score = 0
+
+        for quote in policy_quotes:
+            if quote and quote in text_norm:
+                score += 8
+
+        for hint in reference_hints:
+            if not hint:
+                continue
+            hint_tokens = set(hint.split())
+            score += len(hint_tokens.intersection(title_tokens)) * 2
+            if hint in title_norm or title_norm in hint:
+                score += 4
+
+        if score > best_score:
+            best_score = score
+            best_policy = policy
+
+    return best_policy or policies[0]
 
 
 def build_audio_storage_path(organization_slug: str, interaction_id: UUID, filename: str) -> Path:
@@ -196,6 +260,7 @@ async def reset_interaction_for_reprocess(session: AsyncSession, interaction_id:
     await session.exec(delete(Utterance).where(Utterance.interaction_id == interaction_id))
     await session.exec(delete(PolicyCompliance).where(PolicyCompliance.interaction_id == interaction_id))
     await session.exec(delete(InteractionScore).where(InteractionScore.interaction_id == interaction_id))
+    await session.exec(delete(InteractionLLMTriggerCache).where(InteractionLLMTriggerCache.interaction_id == interaction_id))
 
     transcript_result = await session.exec(
         select(Transcript).where(Transcript.interaction_id == interaction_id)
@@ -280,6 +345,7 @@ async def process_interaction(interaction_id: UUID) -> None:
         await session.exec(delete(Utterance).where(Utterance.interaction_id == interaction_id))
         await session.exec(delete(PolicyCompliance).where(PolicyCompliance.interaction_id == interaction_id))
         await session.exec(delete(InteractionScore).where(InteractionScore.interaction_id == interaction_id))
+        await session.exec(delete(InteractionLLMTriggerCache).where(InteractionLLMTriggerCache.interaction_id == interaction_id))
 
         transcript_result = await session.exec(
             select(Transcript).where(Transcript.interaction_id == interaction_id)
@@ -350,37 +416,46 @@ async def process_interaction(interaction_id: UUID) -> None:
         )
         organization = organization_result.first()
 
-        policy_result = await session.exec(
-            select(CompanyPolicy)
-            .join(OrganizationPolicy, OrganizationPolicy.policy_id == CompanyPolicy.id)
-            .where(
-                OrganizationPolicy.organization_id == interaction.organization_id,
-                OrganizationPolicy.is_active.is_(True),
-                CompanyPolicy.is_active.is_(True),
-            )
-            .order_by(OrganizationPolicy.assigned_at.desc())
-        )
-        policy = policy_result.first()
-
         report = None
         if organization:
             try:
                 report = await evaluate_interaction_triggers(
                     session=session,
                     interaction_id=interaction_id,
-                    ground_truth_policy=policy.policy_text if policy else transcript_text,
                     org_filter=organization.slug,
+                    force_rerun=True,
                 )
             except Exception:
                 logger.exception("LLM trigger evaluation failed for interaction %s", interaction_id)
 
-        if report and policy:
+        if report:
+            policy = await _resolve_policy_record_for_report(
+                session=session,
+                organization_id=interaction.organization_id,
+                report=report,
+            )
             compliance_score = max(0.0, min(1.0, float(report.process_adherence.efficiency_score) / 10.0))
-            policy_score = compliance_score
-            empathy_score = 0.6 if report.emotion_shift.is_dissonance_detected else 0.9
-            resolution_score = 0.9 if report.process_adherence.is_resolved else 0.6
-            overall_score = round((empathy_score + policy_score + resolution_score) / 3, 4)
-            is_compliant = report.nli_policy.nli_category in {"Entailment", "Benign Deviation"}
+            policy_alignment = report.nli_policy.policy_alignment_score
+            if policy_alignment is None:
+                policy_alignment = 1.0 if report.nli_policy.nli_category in {"Entailment", "Benign Deviation"} else 0.35
+            policy_score = max(0.0, min(1.0, (compliance_score * 0.55) + (float(policy_alignment) * 0.45)))
+
+            if report.emotion_shift.is_dissonance_detected:
+                empathy_score = 0.55
+            elif report.emotion_shift.insufficient_evidence:
+                empathy_score = 0.82
+            else:
+                empathy_score = 0.95
+
+            if report.process_adherence.is_resolved:
+                resolution_score = 0.94 if not report.process_adherence.missing_sop_steps else 0.84
+            else:
+                resolution_score = 0.42
+
+            overall_score = round(
+                (empathy_score * 0.3) + (policy_score * 0.4) + (resolution_score * 0.3),
+                4,
+            )
             evidence_text = "; ".join(
                 quote for quote in (
                     report.process_adherence.evidence_quotes[:1] + report.nli_policy.evidence_quotes[:1]
@@ -388,17 +463,19 @@ async def process_interaction(interaction_id: UUID) -> None:
                 if quote
             ) or transcript_text[:250]
 
-            session.add(
-                PolicyCompliance(
-                    interaction_id=interaction_id,
-                    policy_id=policy.id,
-                    is_compliant=is_compliant,
-                    compliance_score=compliance_score,
-                    llm_reasoning=report.nli_policy.justification or report.process_adherence.justification,
-                    evidence_text=evidence_text,
-                    retrieved_policy_text=policy.policy_text,
+            if policy:
+                is_compliant = report.nli_policy.nli_category in {"Entailment", "Benign Deviation"}
+                session.add(
+                    PolicyCompliance(
+                        interaction_id=interaction_id,
+                        policy_id=policy.id,
+                        is_compliant=is_compliant,
+                        compliance_score=compliance_score,
+                        llm_reasoning=report.nli_policy.justification or report.process_adherence.justification,
+                        evidence_text=evidence_text,
+                        retrieved_policy_text=policy.policy_text,
+                    )
                 )
-            )
 
             session.add(
                 InteractionScore(

--- a/backend/app/llm_trigger/prompts.py
+++ b/backend/app/llm_trigger/prompts.py
@@ -10,6 +10,7 @@ Output style:
 - is_dissonance_detected: true
 - dissonance_type: "Sarcasm"
 - root_cause: references lexical positivity with angry prosody
+- confidence_score: float between 0 and 1
 - counterfactual_correction: starts with "If the agent had..."
 - evidence_quotes: includes at least one verbatim quote from customer_text
 - citations: includes structured quote entries with source="transcript"
@@ -22,6 +23,7 @@ Output style:
 - is_dissonance_detected: true
 - dissonance_type: "Passive-Aggression"
 - root_cause: references resignation language with hostile tone
+- confidence_score: float between 0 and 1
 - counterfactual_correction: starts with "If the agent had..."
 - evidence_quotes: includes at least one verbatim quote from customer_text
 - citations: includes structured quote entries with source="transcript"
@@ -33,24 +35,32 @@ Example A:
 - ground_truth_policy: "Refunds are allowed only within 30 days."
 - agent_statement: "I can help process a refund if your purchase is within 30 days."
 - nli_category: "Entailment"
+- confidence_score: 0.94
+- policy_alignment_score: 0.96
 - evidence_quotes: includes one quote from policy and one from agent statement
 
 Example B:
 - ground_truth_policy: "Refunds are allowed only within 30 days."
 - agent_statement: "No worries, I totally understand your frustration. Let me check your purchase date first."
 - nli_category: "Benign Deviation"
+- confidence_score: 0.72
+- policy_alignment_score: 0.51
 - evidence_quotes: includes one quote from policy and one from agent statement
 
 Example C:
 - ground_truth_policy: "Refunds are allowed only within 30 days."
 - agent_statement: "We always allow refunds up to 90 days."
 - nli_category: "Contradiction"
+- confidence_score: 0.95
+- policy_alignment_score: 0.08
 - evidence_quotes: includes one quote from policy and one from agent statement
 
 Example D:
 - ground_truth_policy: "Refunds are allowed only within 30 days."
 - agent_statement: "Policy says refunds require manager approval plus a processing fee."
 - nli_category: "Policy Hallucination"
+- confidence_score: 0.9
+- policy_alignment_score: 0.05
 - evidence_quotes: includes one quote from policy and one from agent statement
 """.strip()
 
@@ -85,8 +95,9 @@ def build_emotion_shift_prompt() -> ChatPromptTemplate:
                 "2) If dissonant, classify type (e.g., Sarcasm, Passive-Aggression).\n"
                 "3) Explain root cause grounded in transcript text. If no clear cause, return 'insufficient evidence'.\n"
                 "4) Provide a correction sentence that starts exactly with 'If the agent had...'.\n"
-                "5) Include evidence_quotes as verbatim excerpts from customer text.\n"
-                "6) Include citations with source, speaker, quote, and utterance_index when known.",
+                "5) Include a confidence_score between 0 and 1 for how certain you are in the dissonance verdict.\n"
+                "6) Include evidence_quotes as verbatim excerpts from customer text.\n"
+                "7) Include citations with source, speaker, quote, and utterance_index when known.",
             ),
         ]
     )
@@ -122,6 +133,7 @@ def build_process_adherence_prompt() -> ChatPromptTemplate:
                 "- Write a short justification paragraph explicitly referencing the transcript evidence.\n"
                 "- Compare transcript trajectory against expected graph/SOP and list missing steps.\n"
                 "- List missed SOP steps precisely as short bullet-style strings.\n"
+                "- Include a confidence_score between 0 and 1 for how certain you are in the process adherence verdict.\n"
                 "- Provide evidence_quotes using exact transcript snippets in double quotes.\n"
                 "- Provide citations with transcript/SOP quote provenance.",
             ),
@@ -154,6 +166,8 @@ def build_nli_policy_prompt() -> ChatPromptTemplate:
                 "Ground truth policy:\n{ground_truth_policy}\n\n"
                 "Agent statement:\n{agent_statement}\n\n"
                 "Classify into one category and justify with textual evidence.\n"
+                "Include confidence_score between 0 and 1 for the final category.\n"
+                "Include policy_alignment_score between 0 and 1 for how strongly policy supports the statement.\n"
                 "Include at least one policy quote and one agent quote in evidence_quotes and citations.",
             ),
         ]

--- a/backend/app/llm_trigger/retrieval.py
+++ b/backend/app/llm_trigger/retrieval.py
@@ -1,15 +1,125 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 import httpx
 from pathlib import Path
+import re
 from qdrant_client import QdrantClient
 from qdrant_client.models import FieldCondition, Filter, MatchValue
 
 from app.core.config import settings
 
 
-class SOPRetriever:
-    """Minimal Qdrant retriever for SOP snippets used by llm_trigger chains."""
+@dataclass
+class RetrievedChunk:
+    text: str
+    score: float | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+    source: str = "qdrant"
+    collection: str | None = None
+
+    @property
+    def reference(self) -> str:
+        for key in ("source_file", "doc_id", "Header 1", "Header 2", "Header 3"):
+            value = self.metadata.get(key)
+            if value:
+                return str(value)
+        return self.source
+
+    @property
+    def provenance(self) -> str:
+        parts = [
+            self.metadata.get("source_file"),
+            self.metadata.get("doc_id"),
+            " > ".join(
+                str(self.metadata.get(key)).strip()
+                for key in ("Header 1", "Header 2", "Header 3")
+                if self.metadata.get(key)
+            ) or None,
+        ]
+        return " • ".join(part for part in parts if part)
+
+
+@dataclass
+class ResolvedRetrievalContext:
+    text: str
+    chunks: list[RetrievedChunk] = field(default_factory=list)
+    source: str = "unknown"
+
+
+def _tokenize(text: str) -> set[str]:
+    return {token for token in re.findall(r"[a-zA-Z]+", (text or "").lower()) if len(token) > 2}
+
+
+def _rank_manual_chunks(
+    transcript_text: str,
+    chunks: list[RetrievedChunk],
+    max_chunks: int = 1,
+) -> list[RetrievedChunk]:
+    if not chunks:
+        return []
+
+    query_tokens = _tokenize(transcript_text)
+    if not query_tokens:
+        return chunks[:max_chunks]
+
+    ranked: list[tuple[float, int, RetrievedChunk]] = []
+    for index, chunk in enumerate(chunks):
+        body_tokens = _tokenize(chunk.text)
+        source_tokens = _tokenize(chunk.metadata.get("source_file", ""))
+        header_tokens = _tokenize(
+            " ".join(
+                str(chunk.metadata.get(key, ""))
+                for key in ("Header 1", "Header 2", "Header 3")
+            )
+        )
+        overlap = (
+            len(query_tokens.intersection(body_tokens))
+            + (2 * len(query_tokens.intersection(source_tokens)))
+            + len(query_tokens.intersection(header_tokens))
+        )
+        if chunk.metadata.get("doc_type") == "sop-procedures":
+            overlap += 1
+        score = min(1.0, overlap / max(3, len(query_tokens)))
+        ranked.append((score, -index, RetrievedChunk(
+            text=chunk.text,
+            score=score,
+            metadata=chunk.metadata,
+            source=chunk.source,
+            collection=chunk.collection,
+        )))
+
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    best_score = ranked[0][0]
+    if best_score <= 0:
+        return [ranked[0][2]]
+    return [chunk for score, _, chunk in ranked if score == best_score][:max_chunks]
+
+
+def _rank_chunks_by_query(
+    query_text: str,
+    chunks: list[RetrievedChunk],
+    max_chunks: int,
+) -> list[RetrievedChunk]:
+    if not chunks:
+        return []
+    query_tokens = _tokenize(query_text)
+    ranked: list[tuple[float, int, RetrievedChunk]] = []
+    for index, chunk in enumerate(chunks):
+        overlap = _tokenize(chunk.text)
+        lexical_score = 0.0
+        if query_tokens and overlap:
+            lexical_score = len(query_tokens.intersection(overlap)) / len(query_tokens.union(overlap))
+        vector_score = float(chunk.score) if chunk.score is not None else 0.0
+        total_score = (vector_score * 0.75) + (lexical_score * 0.25)
+        ranked.append((total_score, -index, chunk))
+
+    ranked.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [chunk for _, _, chunk in ranked[:max_chunks]]
+
+
+class QdrantRetriever:
+    """Shared Qdrant retriever used by llm_trigger explainability paths."""
 
     def __init__(self) -> None:
         self._qdrant = QdrantClient(url=settings.QDRANT_URL)
@@ -37,8 +147,15 @@ class SOPRetriever:
 
         raise ValueError(f"Embedding API did not return vector: {last_error}")
 
-    def retrieve_sop(self, transcript_text: str, org_filter: str | None = None) -> str:
-        query_vector = self._embed_query(transcript_text)
+    def retrieve_chunks(
+        self,
+        query_text: str,
+        *,
+        collection_name: str,
+        top_k: int,
+        org_filter: str | None = None,
+    ) -> list[RetrievedChunk]:
+        query_vector = self._embed_query(query_text)
 
         query_filter = None
         if org_filter:
@@ -47,21 +164,58 @@ class SOPRetriever:
             )
 
         points = self._qdrant.query_points(
-            collection_name=settings.QDRANT_COLLECTION_SOP_PARENTS,
+            collection_name=collection_name,
             query=query_vector,
-            limit=settings.SOP_RETRIEVAL_TOP_K,
+            limit=top_k,
             query_filter=query_filter,
         ).points
 
-        snippets: list[str] = []
+        snippets: list[RetrievedChunk] = []
         for point in points:
             text = ""
+            metadata: dict[str, str] = {}
             if isinstance(point.payload, dict):
                 text = str(point.payload.get("text", "")).strip()
+                metadata = {str(key): str(value) for key, value in point.payload.items() if key != "text" and value is not None}
             if text:
-                snippets.append(text)
+                snippets.append(
+                    RetrievedChunk(
+                        text=text,
+                        score=float(point.score) if point.score is not None else None,
+                        metadata=metadata,
+                        source="qdrant",
+                        collection=collection_name,
+                    )
+                )
 
-        return "\n\n---\n\n".join(snippets)
+        return snippets
+
+
+class SOPRetriever(QdrantRetriever):
+    """Minimal Qdrant retriever for SOP snippets used by llm_trigger chains."""
+
+    def retrieve_sop_chunks(self, transcript_text: str, org_filter: str | None = None) -> list[RetrievedChunk]:
+        return self.retrieve_chunks(
+            query_text=transcript_text,
+            collection_name=settings.QDRANT_COLLECTION_SOP_PARENTS,
+            top_k=settings.SOP_RETRIEVAL_TOP_K,
+            org_filter=org_filter,
+        )
+
+    def retrieve_sop(self, transcript_text: str, org_filter: str | None = None) -> str:
+        return "\n\n---\n\n".join(chunk.text for chunk in self.retrieve_sop_chunks(transcript_text, org_filter))
+
+
+class PolicyRetriever(QdrantRetriever):
+    """Qdrant retriever for policy chunks used in claim provenance."""
+
+    def retrieve_policy_chunks(self, query_text: str, org_filter: str | None = None, top_k: int = 3) -> list[RetrievedChunk]:
+        return self.retrieve_chunks(
+            query_text=query_text,
+            collection_name=settings.QDRANT_COLLECTION_PARENTS,
+            top_k=top_k,
+            org_filter=org_filter,
+        )
 
 
 def _repo_root() -> Path:
@@ -95,9 +249,9 @@ def _resolve_org_parsed_docs_dir(org_filter: str) -> Path:
     return parsed_root / org_filter / "parsed-docs" / "sops"
 
 
-def _read_manual_org_sop_docs(org_filter: str | None) -> str:
+def _read_manual_org_sop_chunks(org_filter: str | None) -> list[RetrievedChunk]:
     if not org_filter:
-        return ""
+        return []
 
     # SOP source of truth is PDF. We read Docling-converted markdown from
     # sop-standards/{org}/parsed-docs by matching PDF basenames.
@@ -113,7 +267,7 @@ def _read_manual_org_sop_docs(org_filter: str | None) -> str:
             sop_dirs.append(candidate)
 
     if not sop_dirs:
-        return ""
+        return []
 
     pdf_paths: list[Path] = []
     seen_pdf_paths: set[Path] = set()
@@ -125,7 +279,7 @@ def _read_manual_org_sop_docs(org_filter: str | None) -> str:
             seen_pdf_paths.add(resolved)
             pdf_paths.append(path)
 
-    chunks: list[str] = []
+    chunks: list[RetrievedChunk] = []
 
     for pdf_path in pdf_paths:
         converted_md = parsed_docs_root / f"{pdf_path.stem}.md"
@@ -144,10 +298,20 @@ def _read_manual_org_sop_docs(org_filter: str | None) -> str:
             continue
         if not text:
             continue
-        chunks.append(f"[{pdf_path.name}]\n{text}")
+        chunks.append(
+            RetrievedChunk(
+                text=f"[{pdf_path.name}]\n{text}",
+                score=None,
+                metadata={
+                    "source_file": pdf_path.name,
+                    "doc_type": pdf_path.parent.name,
+                },
+                source="manual",
+            )
+        )
 
     if chunks:
-        return "\n\n---\n\n".join(chunks)
+        return chunks
 
     # Backward compatibility: allow direct text SOP files if present.
     allowed_suffixes = {".md", ".txt"}
@@ -162,9 +326,85 @@ def _read_manual_org_sop_docs(org_filter: str | None) -> str:
                 continue
             if not text:
                 continue
-            chunks.append(f"[{path.name}]\n{text}")
+            chunks.append(
+                RetrievedChunk(
+                    text=f"[{path.name}]\n{text}",
+                    score=None,
+                    metadata={
+                        "source_file": path.name,
+                        "doc_type": path.parent.name,
+                    },
+                    source="manual",
+                )
+            )
 
-    return "\n\n---\n\n".join(chunks)
+    return chunks
+
+
+def _join_chunks(chunks: list[RetrievedChunk]) -> str:
+    return "\n\n---\n\n".join(chunk.text for chunk in chunks if chunk.text)
+
+
+def _read_manual_org_sop_docs(org_filter: str | None) -> str:
+    return _join_chunks(_read_manual_org_sop_chunks(org_filter))
+
+
+def resolve_retrieved_sop_context(
+    transcript_text: str,
+    retrieved_sop_from_pinecone: str | None,
+    org_filter: str | None = None,
+) -> ResolvedRetrievalContext:
+    if retrieved_sop_from_pinecone and retrieved_sop_from_pinecone.strip():
+        chunk = RetrievedChunk(
+            text=retrieved_sop_from_pinecone.strip(),
+            score=None,
+            metadata={"source": "override"},
+            source="override",
+        )
+        return ResolvedRetrievalContext(text=chunk.text, chunks=[chunk], source="override")
+
+    manual_chunks = _read_manual_org_sop_chunks(org_filter)
+    if manual_chunks:
+        ranked_manual_chunks = _rank_manual_chunks(
+            transcript_text=transcript_text,
+            chunks=manual_chunks,
+            max_chunks=1,
+        )
+        return ResolvedRetrievalContext(
+            text=_join_chunks(ranked_manual_chunks),
+            chunks=ranked_manual_chunks,
+            source="manual",
+        )
+
+    qdrant_chunks: list[RetrievedChunk] = []
+    try:
+        retriever = SOPRetriever()
+        qdrant_chunks = retriever.retrieve_sop_chunks(transcript_text=transcript_text, org_filter=org_filter)
+    except Exception:
+        qdrant_chunks = []
+
+    if qdrant_chunks:
+        ranked_qdrant_chunks = _rank_chunks_by_query(
+            query_text=transcript_text,
+            chunks=qdrant_chunks,
+            max_chunks=1,
+        )
+        return ResolvedRetrievalContext(
+            text=_join_chunks(ranked_qdrant_chunks),
+            chunks=ranked_qdrant_chunks,
+            source="qdrant",
+        )
+
+    return ResolvedRetrievalContext(text="", chunks=[], source="none")
+
+
+def retrieve_policy_chunks(
+    query_text: str,
+    org_filter: str | None = None,
+    top_k: int = 3,
+) -> list[RetrievedChunk]:
+    retriever = PolicyRetriever()
+    return retriever.retrieve_policy_chunks(query_text=query_text, org_filter=org_filter, top_k=top_k)
 
 
 def resolve_retrieved_sop(
@@ -172,12 +412,8 @@ def resolve_retrieved_sop(
     retrieved_sop_from_pinecone: str | None,
     org_filter: str | None = None,
 ) -> str:
-    if retrieved_sop_from_pinecone and retrieved_sop_from_pinecone.strip():
-        return retrieved_sop_from_pinecone.strip()
-
-    manual_sop = _read_manual_org_sop_docs(org_filter)
-    if manual_sop:
-        return manual_sop
-
-    retriever = SOPRetriever()
-    return retriever.retrieve_sop(transcript_text=transcript_text, org_filter=org_filter)
+    return resolve_retrieved_sop_context(
+        transcript_text=transcript_text,
+        retrieved_sop_from_pinecone=retrieved_sop_from_pinecone,
+        org_filter=org_filter,
+    ).text

--- a/backend/app/llm_trigger/schemas.py
+++ b/backend/app/llm_trigger/schemas.py
@@ -6,6 +6,16 @@ from pydantic import BaseModel, Field, field_validator
 
 CitationSource = Literal["transcript", "policy", "sop", "acoustic"]
 CitationSpeaker = Literal["customer", "agent", "system", "unknown"]
+ExplainabilityFamily = Literal["emotion", "sop", "policy"]
+ExplainabilityVerdict = Literal[
+    "Supported",
+    "Partial Attempt",
+    "Neutral",
+    "Contradiction",
+    "Cross-Modal Mismatch",
+    "No Trigger",
+    "Insufficient Evidence",
+]
 
 
 class EvidenceCitation(BaseModel):
@@ -17,6 +27,66 @@ class EvidenceCitation(BaseModel):
         ge=0,
         description="Utterance index for transcript citations when known.",
     )
+
+
+class EvidenceSpan(BaseModel):
+    utterance_index: int | None = Field(
+        default=None,
+        ge=0,
+        description="Sequence index for the supporting utterance when the evidence comes from the transcript.",
+    )
+    speaker: CitationSpeaker = Field(default="unknown")
+    quote: str = Field(description="Span quote shown to supervisors.")
+    timestamp: str | None = Field(default=None, description="Clock timestamp for the supporting span.")
+    start_seconds: float | None = Field(default=None, ge=0, description="Audio jump target in seconds.")
+    end_seconds: float | None = Field(default=None, ge=0, description="Span end time in seconds.")
+
+
+class PolicyReference(BaseModel):
+    source: Literal["policy", "sop"] = Field(description="Whether the reference came from a policy or SOP document.")
+    reference: str = Field(description="Human-readable document or section reference.")
+    clause: str = Field(description="Policy or SOP clause used as evidence.")
+    version: str | None = Field(default=None, description="Version or policy token when available.")
+    category: str | None = Field(default=None, description="Policy category when available.")
+    provenance: str | None = Field(
+        default=None,
+        description="Retrieval provenance such as document path, parent section, or chunk label.",
+    )
+
+
+class TriggerAttribution(BaseModel):
+    attribution_id: str = Field(description="Stable identifier for the trigger attribution card.")
+    family: ExplainabilityFamily = Field(description="High-level explainability family.")
+    trigger_type: str = Field(description="Trigger class such as Acoustic-Transcript Dissonance or SOP Violation.")
+    title: str = Field(description="Short manager-facing title.")
+    verdict: ExplainabilityVerdict = Field(description="Final explainability verdict.")
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    evidence_span: EvidenceSpan | None = Field(default=None)
+    policy_reference: PolicyReference | None = Field(default=None)
+    reasoning: str = Field(description="Plain-English reason for the verdict.")
+    evidence_chain: list[str] = Field(
+        default_factory=list,
+        description="Structured reasoning steps that connect the span to the verdict.",
+    )
+    supporting_quotes: list[str] = Field(default_factory=list)
+
+
+class ClaimProvenance(BaseModel):
+    claim_id: str = Field(description="Stable identifier for the claim provenance card.")
+    claim_text: str = Field(description="Agent claim or answer sentence.")
+    claim_span: EvidenceSpan | None = Field(default=None)
+    retrieved_policy: PolicyReference | None = Field(default=None)
+    semantic_similarity: float | None = Field(default=None, ge=0.0, le=1.0)
+    nli_verdict: ExplainabilityVerdict = Field(description="Policy-grounded verdict for the claim.")
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    reasoning: str = Field(description="Manager-facing explanation of how the claim was judged.")
+    provenance: str = Field(description="Compact retrieval provenance trail.")
+    supporting_quotes: list[str] = Field(default_factory=list)
+
+
+class EvidenceAnchoredExplainability(BaseModel):
+    trigger_attributions: list[TriggerAttribution] = Field(default_factory=list)
+    claim_provenance: list[ClaimProvenance] = Field(default_factory=list)
 
 
 def _normalize_quote_list(value: list[str] | str | None) -> list[str]:
@@ -71,6 +141,12 @@ class EmotionShiftAnalysis(BaseModel):
         default=False,
         description="True when the analysis had to be downgraded due to missing or unmapped evidence.",
     )
+    confidence_score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Model or signal confidence for the dissonance verdict when available.",
+    )
 
     @field_validator("counterfactual_correction", mode="before")
     @classmethod
@@ -121,6 +197,12 @@ class ProcessAdherenceReport(BaseModel):
         default=False,
         description="True when process verdict could not be grounded to transcript evidence.",
     )
+    confidence_score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Model confidence for the process adherence assessment when available.",
+    )
 
     @field_validator("evidence_quotes", mode="before")
     @classmethod
@@ -167,6 +249,18 @@ class NLIEvaluation(BaseModel):
         default=False,
         description="True when NLI verdict had insufficient policy-grounded evidence.",
     )
+    confidence_score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Model confidence for the final NLI category when available.",
+    )
+    policy_alignment_score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="How strongly the statement is supported by policy. Low values imply contradiction or hallucination.",
+    )
 
     @field_validator("evidence_quotes", mode="before")
     @classmethod
@@ -183,3 +277,4 @@ class InteractionLLMTriggerReport(BaseModel):
     derived_acoustic_emotion: str
     derived_fused_emotion: str
     derived_agent_statement: str
+    explainability: EvidenceAnchoredExplainability = Field(default_factory=EvidenceAnchoredExplainability)

--- a/backend/app/llm_trigger/service.py
+++ b/backend/app/llm_trigger/service.py
@@ -16,15 +16,21 @@ from app.llm_trigger.chains import (
     build_nli_policy_chain,
     build_process_adherence_chain,
 )
-from app.llm_trigger.retrieval import resolve_retrieved_sop
+from app.llm_trigger.retrieval import RetrievedChunk, resolve_retrieved_sop_context, retrieve_policy_chunks
 from app.llm_trigger.schemas import (
+    ClaimProvenance,
+    EvidenceAnchoredExplainability,
     EvidenceCitation,
+    EvidenceSpan,
     EmotionShiftAnalysis,
     InteractionLLMTriggerReport,
     NLIEvaluation,
+    PolicyReference,
     ProcessAdherenceReport,
+    TriggerAttribution,
 )
 from app.models.interaction import Interaction
+from app.models.llm_trigger_cache import InteractionLLMTriggerCache
 from app.models.policy import CompanyPolicy, OrganizationPolicy
 from app.models.transcript import Transcript
 from app.models.utterance import Utterance
@@ -92,6 +98,19 @@ class ResolvedPolicyContext:
     conflict_resolution_applied: bool = False
 
 
+def _join_retrieved_chunk_text(chunks: list[RetrievedChunk]) -> str:
+    return "\n\n---\n\n".join(chunk.text.strip() for chunk in chunks if chunk.text.strip())
+
+
+def _policy_chunk_reference(chunk: RetrievedChunk) -> str:
+    header_path = " > ".join(
+        str(chunk.metadata.get(key)).strip()
+        for key in ("Header 1", "Header 2", "Header 3")
+        if chunk.metadata.get(key)
+    )
+    return header_path or str(chunk.metadata.get("source_file") or chunk.metadata.get("doc_id") or "retrieved-policy")
+
+
 def _tokenize(text: str) -> list[str]:
     return re.findall(r"[a-zA-Z]+", text.lower())
 
@@ -136,6 +155,37 @@ def _detect_topic(transcript_text: str, retrieved_sop: str) -> str:
         scores[topic] = sum(1 for keyword in keywords if keyword in source)
     best_topic = max(scores, key=scores.get)
     return best_topic if scores[best_topic] > 0 else "technical_support"
+
+
+def _detect_topic_from_sop_chunks(chunks: list[RetrievedChunk]) -> str | None:
+    if not chunks:
+        return None
+
+    source_text = " ".join(
+        str(value)
+        for chunk in chunks
+        for value in (
+            chunk.metadata.get("source_file"),
+            chunk.metadata.get("doc_id"),
+            chunk.metadata.get("Header 1"),
+            chunk.metadata.get("Header 2"),
+            chunk.metadata.get("Header 3"),
+            chunk.reference,
+            chunk.provenance,
+        )
+        if value
+    ).lower()
+
+    hint_map = {
+        "refund_request": ("01-refund", "refund request", "refund-request"),
+        "billing_issue": ("02-billing", "billing issue", "billing-issue"),
+        "technical_support": ("03-technical", "technical support", "technical-support"),
+        "account_access": ("04-account", "account access", "account-access"),
+    }
+    for topic, hints in hint_map.items():
+        if any(hint in source_text for hint in hints):
+            return topic
+    return None
 
 
 def _extract_sop_steps(retrieved_sop: str) -> list[str]:
@@ -190,6 +240,28 @@ def _trajectory_missing_steps(transcript_text: str, expected_steps: list[str]) -
         if overlap < threshold:
             missing.append(step)
     return missing
+
+
+def _merge_missing_steps(
+    deterministic_missing: list[str],
+    llm_missing: list[str],
+) -> list[str]:
+    if not llm_missing:
+        return deterministic_missing
+    if not deterministic_missing:
+        return deterministic_missing
+
+    normalized_deterministic = {step.lower(): step for step in deterministic_missing}
+    merged = list(deterministic_missing)
+    for llm_step in llm_missing:
+      llm_keywords = _step_keywords(llm_step)
+      for expected_lower, original_step in normalized_deterministic.items():
+          expected_keywords = _step_keywords(expected_lower)
+          if llm_keywords and expected_keywords and llm_keywords.intersection(expected_keywords):
+              if original_step not in merged:
+                  merged.append(original_step)
+              break
+    return merged
 
 
 def _is_resolved_heuristic(transcript_text: str) -> bool:
@@ -446,6 +518,8 @@ async def _resolve_active_policy_context(
     organization_id: UUID,
     ground_truth_policy: str,
     fallback_sop: str,
+    query_text: str,
+    org_filter: str | None,
 ) -> ResolvedPolicyContext:
     if ground_truth_policy.strip():
         return ResolvedPolicyContext(
@@ -454,6 +528,40 @@ async def _resolve_active_policy_context(
             category="override",
             conflict_resolution_applied=False,
         )
+
+    retrieval_query = query_text.strip() or fallback_sop.strip()
+    if retrieval_query:
+        try:
+            retrieved_policy_chunks = retrieve_policy_chunks(
+                query_text=retrieval_query,
+                org_filter=org_filter,
+                top_k=2,
+            )
+        except Exception:
+            retrieved_policy_chunks = []
+
+        if retrieved_policy_chunks:
+            primary_chunk = retrieved_policy_chunks[0]
+            primary_source = str(
+                primary_chunk.metadata.get("source_file")
+                or primary_chunk.metadata.get("doc_id")
+                or ""
+            ).strip()
+            contextual_chunks = [
+                chunk
+                for chunk in retrieved_policy_chunks
+                if not primary_source
+                or str(chunk.metadata.get("source_file") or chunk.metadata.get("doc_id") or "").strip() == primary_source
+            ] or [primary_chunk]
+            primary_reference = _policy_chunk_reference(primary_chunk)
+            reference_basis = str(primary_chunk.metadata.get("source_file") or primary_chunk.metadata.get("doc_id") or primary_reference)
+            unique_references = {_policy_chunk_reference(chunk) for chunk in contextual_chunks}
+            return ResolvedPolicyContext(
+                text=_join_retrieved_chunk_text(contextual_chunks),
+                version=f"retrieved:{reference_basis}",
+                category=str(primary_chunk.metadata.get("doc_type") or primary_chunk.metadata.get("category") or "retrieved"),
+                conflict_resolution_applied=len(unique_references) > 1,
+            )
 
     stmt = (
         select(
@@ -501,6 +609,568 @@ async def _resolve_active_policy_context(
 def _format_timestamp(seconds: float) -> str:
     seconds_int = max(0, int(seconds))
     return f"{seconds_int // 60:02d}:{seconds_int % 60:02d}"
+
+
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+def _utterance_speaker(utterance: Utterance | None) -> str:
+    if not utterance or not utterance.speaker_role:
+        return "unknown"
+    return utterance.speaker_role.value
+
+
+def _find_utterance_by_index(
+    utterances: list[Utterance],
+    utterance_index: int | None,
+) -> Utterance | None:
+    if utterance_index is None:
+        return None
+    for utterance in utterances:
+        if utterance.sequence_index == utterance_index:
+            return utterance
+    return None
+
+
+def _extract_reference_label(text: str, fallback: str) -> str:
+    for raw_line in text.splitlines():
+        line = _clean_display_text(raw_line)
+        if not line:
+            continue
+        bracket_match = re.match(r"^\[(.+?)\]$", line)
+        if bracket_match:
+            return bracket_match.group(1).strip()
+        if line.startswith("#"):
+            return line.lstrip("#").strip()
+        return line[:120]
+    return fallback
+
+
+def _clean_display_text(text: str | None) -> str:
+    cleaned = (text or "").replace("\r", "")
+    cleaned = re.sub(r"<!--.*?-->", " ", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r"^\s*#{1,6}\s*", "", cleaned, flags=re.MULTILINE)
+    cleaned = cleaned.replace("â€¢", " / ").replace("Ã¢â‚¬Â¢", " / ")
+    cleaned = re.sub(r"\b(image|table)\b", " ", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(r"[_]{2,}", "_", cleaned)
+    cleaned = re.sub(r"[-|]{4,}", " ", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip()
+
+
+def _extract_display_clause(text: str, max_chars: int = 260) -> str:
+    preferred_lines: list[str] = []
+    fallback_lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = _clean_display_text(raw_line)
+        if not line:
+            continue
+        if re.match(r"^\[.+\]$", line):
+            continue
+        lowered = line.lower()
+        if lowered.endswith(".pdf") or lowered in {
+            "overview",
+            "organization:",
+            "version:",
+            "effective date:",
+            "step-by-step procedure",
+            "related policies",
+            "key considerations",
+            "eligibility criteria",
+        }:
+            continue
+        fallback_lines.append(line)
+        if line.lower().startswith(("step ", "compliance:", "note:", "forbidden", "quote the correct timeline", "offer ", "provide ", "verify ", "apply ", "escalate ")):
+            preferred_lines.append(line)
+
+    candidate_lines = preferred_lines or fallback_lines
+    if not candidate_lines:
+        return _truncate_text(_clean_display_text(text), max_chars) or "No clause available."
+
+    snippet = " ".join(candidate_lines[:2])
+    return _truncate_text(snippet, max_chars) or "No clause available."
+
+
+def _span_from_citation(
+    citation: EvidenceCitation | None,
+    utterances: list[Utterance],
+) -> EvidenceSpan | None:
+    if not citation or not (citation.quote or "").strip():
+        return None
+
+    utterance = _find_utterance_by_index(utterances, citation.utterance_index)
+    speaker = citation.speaker
+    if speaker == "unknown" and utterance:
+        speaker = _utterance_speaker(utterance)  # type: ignore[assignment]
+
+    start_seconds = utterance.start_time_seconds if utterance else None
+    end_seconds = utterance.end_time_seconds if utterance else None
+
+    return EvidenceSpan(
+        utterance_index=citation.utterance_index,
+        speaker=speaker,
+        quote=citation.quote.strip(),
+        timestamp=_format_timestamp(start_seconds) if start_seconds is not None else None,
+        start_seconds=start_seconds,
+        end_seconds=end_seconds,
+    )
+
+
+def _best_citation(
+    citations: list[EvidenceCitation],
+    source: str,
+    speaker: str | None = None,
+) -> EvidenceCitation | None:
+    for citation in citations:
+        if citation.source != source:
+            continue
+        if speaker and citation.speaker != speaker:
+            continue
+        if (citation.quote or "").strip():
+            return citation
+    return None
+
+
+def _supporting_quotes(citations: list[EvidenceCitation], limit: int = 3) -> list[str]:
+    quotes: list[str] = []
+    seen: set[str] = set()
+    for citation in citations:
+        quote = (citation.quote or "").strip()
+        if not quote or quote in seen:
+            continue
+        seen.add(quote)
+        quotes.append(quote)
+        if len(quotes) >= limit:
+            break
+    return quotes
+
+
+def _best_retrieved_chunk(chunks: list[RetrievedChunk], query_text: str) -> RetrievedChunk | None:
+    if not chunks:
+        return None
+    return max(
+        chunks,
+        key=lambda chunk: (
+            float(chunk.score) if chunk.score is not None else -1.0,
+            _token_overlap_ratio(query_text, chunk.text),
+            len(chunk.text),
+        ),
+    )
+
+
+def _chunk_source_key(chunk: RetrievedChunk | None) -> str:
+    if not chunk:
+        return ""
+    return str(chunk.metadata.get("source_file") or chunk.metadata.get("doc_id") or "").strip().lower()
+
+
+def _filter_chunks_by_policy_context(
+    chunks: list[RetrievedChunk],
+    policy_context: ResolvedPolicyContext,
+) -> list[RetrievedChunk]:
+    version = (policy_context.version or "").strip()
+    if not version.startswith("retrieved:"):
+        return chunks
+    expected_key = version.split("retrieved:", 1)[1].strip().lower()
+    if not expected_key:
+        return chunks
+    filtered = [chunk for chunk in chunks if expected_key in _chunk_source_key(chunk)]
+    return filtered or chunks
+
+
+def _build_policy_reference(
+    citation: EvidenceCitation | None,
+    *,
+    source_kind: str,
+    source_text: str,
+    fallback_reference: str,
+    version: str | None = None,
+    category: str | None = None,
+    provenance: str | None = None,
+) -> PolicyReference | None:
+    clause = ""
+    if citation and (citation.quote or "").strip():
+        clause = _clean_display_text(citation.quote)
+    if not clause:
+        clause = _extract_display_clause(source_text)
+    if not clause:
+        return None
+
+    return PolicyReference(
+        source=source_kind,  # type: ignore[arg-type]
+        reference=_clean_display_text(_extract_reference_label(source_text, fallback_reference)),
+        clause=clause,
+        version=version,
+        category=category,
+        provenance=_clean_display_text(provenance),
+    )
+
+
+def _build_policy_reference_from_chunk(
+    chunk: RetrievedChunk | None,
+    *,
+    source_kind: str,
+    fallback_text: str,
+    fallback_reference: str,
+    version: str | None = None,
+    category: str | None = None,
+) -> PolicyReference | None:
+    if chunk and chunk.text.strip():
+        clause = _extract_display_clause(chunk.text)
+        return PolicyReference(
+            source=source_kind,  # type: ignore[arg-type]
+            reference=_clean_display_text(_extract_reference_label(chunk.text, chunk.reference or fallback_reference)),
+            clause=clause or _truncate_text(_clean_display_text(chunk.text), 220),
+            version=version,
+            category=category,
+            provenance=_clean_display_text(chunk.provenance or chunk.collection or chunk.source),
+        )
+    return _build_policy_reference(
+        None,
+        source_kind=source_kind,
+        source_text=fallback_text,
+        fallback_reference=fallback_reference,
+        version=version,
+        category=category,
+        provenance=None,
+    )
+
+
+def _token_overlap_ratio(left: str, right: str) -> float:
+    left_tokens = set(_tokenize(left))
+    right_tokens = set(_tokenize(right))
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens.intersection(right_tokens)) / len(left_tokens.union(right_tokens))
+
+
+def _emotion_signal_confidence(
+    span: EvidenceSpan | None,
+    utterances: list[Utterance],
+) -> float | None:
+    acoustic_confidence: float | None = None
+    if span and span.utterance_index is not None:
+        utterance = _find_utterance_by_index(utterances, span.utterance_index)
+        if utterance and utterance.emotion_confidence is not None:
+            acoustic_confidence = float(utterance.emotion_confidence)
+
+    text_confidence: float | None = None
+    if span and span.quote.strip():
+        _label, text_confidence = infer_text_emotion_with_provider(span.quote)
+
+    available = [score for score in [acoustic_confidence, text_confidence] if score is not None]
+    if not available:
+        return None
+    return _clamp_unit(sum(available) / len(available))
+
+
+def _select_step_citation(
+    citations: list[EvidenceCitation],
+    step: str,
+) -> EvidenceCitation | None:
+    transcript_citations = [citation for citation in citations if citation.source == "transcript"]
+    if not transcript_citations:
+        return None
+    best = max(
+        transcript_citations,
+        key=lambda citation: _token_overlap_ratio(step, citation.quote),
+    )
+    if _token_overlap_ratio(step, best.quote) < 0.08:
+        return None
+    return best
+
+
+def _map_nli_verdict(category: str, insufficient_evidence: bool = False) -> str:
+    if insufficient_evidence:
+        return "Insufficient Evidence"
+    normalized = (category or "").strip().lower()
+    if normalized == "entailment":
+        return "Supported"
+    if normalized == "contradiction":
+        return "Contradiction"
+    if normalized == "policy hallucination":
+        return "Contradiction"
+    if normalized == "benign deviation":
+        return "Neutral"
+    return "Neutral"
+
+
+def _build_emotion_trigger_attribution(
+    emotion_shift: EmotionShiftAnalysis,
+    utterances: list[Utterance],
+    acoustic_emotion: str,
+) -> TriggerAttribution:
+    transcript_citation = _best_citation(emotion_shift.citations, "transcript", speaker="customer") or _best_citation(
+        emotion_shift.citations,
+        "transcript",
+    )
+    span = _span_from_citation(transcript_citation, utterances)
+    verdict = (
+        "Insufficient Evidence"
+        if emotion_shift.insufficient_evidence
+        else "Cross-Modal Mismatch"
+        if emotion_shift.is_dissonance_detected
+        else "No Trigger"
+    )
+    evidence_chain = [
+        f"Acoustic emotion signal resolved to {acoustic_emotion}.",
+        f"Transcript span used for review: {(span.quote if span else 'No mapped transcript span was available.')}",
+        emotion_shift.root_cause,
+    ]
+
+    return TriggerAttribution(
+        attribution_id="emotion-dissonance",
+        family="emotion",
+        trigger_type="Acoustic-Transcript Dissonance",
+        title=emotion_shift.dissonance_type or "Cross-Modal Dissonance",
+        verdict=verdict,  # type: ignore[arg-type]
+        confidence=emotion_shift.confidence_score or _emotion_signal_confidence(span, utterances),
+        evidence_span=span,
+        reasoning=emotion_shift.root_cause,
+        evidence_chain=evidence_chain,
+        supporting_quotes=emotion_shift.evidence_quotes or _supporting_quotes(emotion_shift.citations),
+    )
+
+
+def _build_emotion_transition_attributions(
+    utterances: list[Utterance],
+) -> list[TriggerAttribution]:
+    attributions: list[TriggerAttribution] = []
+    previous_by_speaker: dict[str, Utterance] = {}
+
+    for utterance in utterances:
+        if not (utterance.text or "").strip():
+            continue
+        speaker = _utterance_speaker(utterance)
+        previous = previous_by_speaker.get(speaker)
+        previous_by_speaker[speaker] = utterance
+        if previous is None:
+            continue
+
+        before = _normalize_acoustic_label(previous.emotion or "neutral")
+        after = _normalize_acoustic_label(utterance.emotion or "neutral")
+        if before == after:
+            continue
+
+        span = EvidenceSpan(
+            utterance_index=utterance.sequence_index,
+            speaker=speaker,  # type: ignore[arg-type]
+            quote=(utterance.text or "").strip(),
+            timestamp=_format_timestamp(utterance.start_time_seconds or 0.0),
+            start_seconds=utterance.start_time_seconds,
+            end_seconds=utterance.end_time_seconds,
+        )
+        evidence_chain = [
+            f"{speaker.title()} emotion changed from {before} to {after}.",
+            f"Previous span: {(previous.text or '').strip() or 'No prior span available.'}",
+            f"Current span: {(utterance.text or '').strip()}",
+        ]
+        reasoning = (
+            f"{speaker.title()} emotion shifted from {before} to {after} at {span.timestamp} "
+            "based on the detected emotion label for this utterance."
+        )
+        attributions.append(
+            TriggerAttribution(
+                attribution_id=f"emotion-change-{speaker}-{utterance.sequence_index}",
+                family="emotion",
+                trigger_type="Emotion Change",
+                title=f"{speaker.title()} emotion: {before} to {after}",
+                verdict="Neutral",
+                confidence=_clamp_unit(float(utterance.emotion_confidence or 0.5)),
+                evidence_span=span,
+                reasoning=reasoning,
+                evidence_chain=evidence_chain,
+                supporting_quotes=[
+                    quote
+                    for quote in [
+                        (previous.text or "").strip(),
+                        (utterance.text or "").strip(),
+                    ]
+                    if quote
+                ],
+            )
+        )
+
+    return attributions
+
+
+def _build_process_trigger_attributions(
+    process_adherence: ProcessAdherenceReport,
+    utterances: list[Utterance],
+    sop_context: str,
+    sop_chunks: list[RetrievedChunk],
+) -> list[TriggerAttribution]:
+    if not process_adherence.missing_sop_steps:
+        return []
+
+    attributions: list[TriggerAttribution] = []
+    for index, step in enumerate(process_adherence.missing_sop_steps, start=1):
+        transcript_citation = _select_step_citation(process_adherence.citations, step)
+        span = _span_from_citation(transcript_citation, utterances)
+        overlap = _token_overlap_ratio(step, transcript_citation.quote if transcript_citation else "")
+        sop_citation = _best_citation(process_adherence.citations, "sop")
+        best_sop_chunk = _best_retrieved_chunk(sop_chunks, step)
+        policy_reference = _build_policy_reference_from_chunk(
+            best_sop_chunk,
+            source_kind="sop",
+            fallback_text=sop_citation.quote if sop_citation else sop_context,
+            fallback_reference="Retrieved SOP",
+        )
+        verdict = "Partial Attempt" if overlap >= 0.18 else "Contradiction"
+        evidence_chain = [
+            f"Expected SOP step: {step}.",
+            f"Closest transcript evidence: {(span.quote if span else 'No matching utterance span was recovered.')}",
+            process_adherence.justification,
+        ]
+        reasoning = (
+            f"The review looked for explicit execution of the SOP step '{step}'. "
+            f"{('A nearby transcript span was found but did not fully satisfy the step. ' if span else 'No reliable transcript span matched this step. ')}"
+            f"{process_adherence.justification}"
+        )
+
+        attributions.append(
+            TriggerAttribution(
+                attribution_id=f"sop-step-{index}",
+                family="sop",
+                trigger_type="SOP Violation",
+                title=step,
+                verdict=verdict,  # type: ignore[arg-type]
+                confidence=process_adherence.confidence_score or (best_sop_chunk.score if best_sop_chunk else None),
+                evidence_span=span,
+                policy_reference=PolicyReference.model_validate(policy_reference.model_dump()) if policy_reference else None,
+                reasoning=reasoning,
+                evidence_chain=evidence_chain,
+                supporting_quotes=[quote for quote in [span.quote if span else None, step] if quote],
+            )
+        )
+
+    return attributions
+
+
+def _fallback_claim_citations(agent_statement: str) -> list[EvidenceCitation]:
+    return [
+        EvidenceCitation(source="transcript", speaker="agent", quote=quote)
+        for quote in _quote_candidates(agent_statement, max_quotes=2)
+    ]
+
+
+def _build_claim_provenance_cards(
+    nli_policy: NLIEvaluation,
+    utterances: list[Utterance],
+    policy_context: ResolvedPolicyContext,
+    agent_statement: str,
+    policy_chunks: list[RetrievedChunk],
+    org_filter: str | None,
+) -> list[ClaimProvenance]:
+    claim_citations = [
+        citation
+        for citation in nli_policy.citations
+        if citation.source == "transcript" and citation.speaker in {"agent", "unknown"}
+    ]
+    if not claim_citations:
+        claim_citations = _fallback_claim_citations(agent_statement)
+
+    cards: list[ClaimProvenance] = []
+    verdict = _map_nli_verdict(nli_policy.nli_category, nli_policy.insufficient_evidence)
+    for index, citation in enumerate(claim_citations[:2], start=1):
+        span = _span_from_citation(citation, utterances)
+        claim_text = (citation.quote or "").strip()
+        policy_citation = _best_citation(nli_policy.citations, "policy")
+        per_claim_chunks: list[RetrievedChunk] = []
+        if claim_text:
+            try:
+                per_claim_chunks = retrieve_policy_chunks(
+                    query_text=claim_text,
+                    org_filter=org_filter,
+                    top_k=2,
+                )
+            except Exception:
+                per_claim_chunks = []
+        candidate_chunks = _filter_chunks_by_policy_context(
+            per_claim_chunks or policy_chunks,
+            policy_context,
+        )
+        best_policy_chunk = _best_retrieved_chunk(candidate_chunks, claim_text)
+        policy_reference = _build_policy_reference_from_chunk(
+            best_policy_chunk,
+            source_kind="policy",
+            fallback_text=policy_citation.quote if policy_citation else policy_context.text,
+            fallback_reference=f"{policy_context.category or 'Policy'} reference",
+            version=policy_context.version,
+            category=policy_context.category,
+        )
+        if not policy_reference:
+            continue
+
+        provenance = " | ".join(
+            part
+            for part in [
+                policy_reference.reference,
+                policy_reference.provenance,
+            ]
+            if part
+        )
+
+        cards.append(
+            ClaimProvenance(
+                claim_id=f"claim-{index}",
+                claim_text=claim_text,
+                claim_span=span,
+                retrieved_policy=PolicyReference.model_validate(policy_reference.model_dump()),
+                semantic_similarity=_clamp_unit(best_policy_chunk.score) if best_policy_chunk and best_policy_chunk.score is not None else None,
+                nli_verdict=verdict,  # type: ignore[arg-type]
+                confidence=nli_policy.confidence_score,
+                reasoning=nli_policy.justification,
+                provenance=provenance or "Active policy context",
+                supporting_quotes=[quote for quote in [claim_text, policy_reference.clause] if quote],
+            )
+        )
+
+    return cards
+
+
+def _build_explainability_layer(
+    emotion_shift: EmotionShiftAnalysis,
+    process_adherence: ProcessAdherenceReport,
+    nli_policy: NLIEvaluation,
+    utterances: list[Utterance],
+    acoustic_emotion: str,
+    sop_context: str,
+    sop_chunks: list[RetrievedChunk],
+    policy_context: ResolvedPolicyContext,
+    policy_chunks: list[RetrievedChunk],
+    agent_statement: str,
+    org_filter: str | None,
+) -> EvidenceAnchoredExplainability:
+    trigger_attributions: list[TriggerAttribution] = [
+        _build_emotion_trigger_attribution(
+            emotion_shift=emotion_shift,
+            utterances=utterances,
+            acoustic_emotion=acoustic_emotion,
+        )
+    ]
+    trigger_attributions.extend(_build_emotion_transition_attributions(utterances))
+    trigger_attributions.extend(
+        _build_process_trigger_attributions(
+            process_adherence=process_adherence,
+            utterances=utterances,
+            sop_context=sop_context,
+            sop_chunks=sop_chunks,
+        )
+    )
+
+    return EvidenceAnchoredExplainability(
+        trigger_attributions=trigger_attributions,
+        claim_provenance=_build_claim_provenance_cards(
+            nli_policy=nli_policy,
+            utterances=utterances,
+            policy_context=policy_context,
+            policy_chunks=policy_chunks,
+            agent_statement=agent_statement,
+            org_filter=org_filter,
+        ),
+    )
 
 
 def _reconstruct_transcript(utterances: list[Utterance]) -> str:
@@ -635,6 +1305,7 @@ async def analyze_emotion_shift(
     acoustic_emotion: str,
 ) -> EmotionShiftAnalysis:
     inferred_emotion = _normalize_acoustic_label(acoustic_emotion)
+    _text_emotion, text_confidence = infer_text_emotion_with_provider(customer_text)
     if not _detect_cross_modal_dissonance(customer_text, acoustic_emotion):
         quotes = _quote_candidates(customer_text, max_quotes=2, target_emotion=inferred_emotion)
         return EmotionShiftAnalysis(
@@ -657,6 +1328,7 @@ async def analyze_emotion_shift(
                 )
                 for quote in quotes
             ],
+            confidence_score=_clamp_unit(text_confidence),
         )
 
     chain = build_emotion_shift_chain()
@@ -688,6 +1360,7 @@ async def analyze_emotion_shift(
                 quotes=quotes,
             ),
             insufficient_evidence=True,
+            confidence_score=None,
         )
     result.is_dissonance_detected = True
     if result.dissonance_type.strip().lower() == "none":
@@ -711,6 +1384,8 @@ async def analyze_emotion_shift(
         root_cause=result.root_cause,
         quotes=result.evidence_quotes,
     )
+    if result.confidence_score is None:
+        result.confidence_score = _clamp_unit(text_confidence)
     return result
 
 
@@ -718,20 +1393,29 @@ async def evaluate_process_adherence(
     transcript_text: str,
     retrieved_sop_from_pinecone: str,
     org_filter: str | None = None,
+    retrieved_sop_chunks: list[RetrievedChunk] | None = None,
 ) -> ProcessAdherenceReport:
-    try:
-        retrieved_sop = resolve_retrieved_sop(
-            transcript_text=transcript_text,
-            retrieved_sop_from_pinecone=retrieved_sop_from_pinecone,
-            org_filter=org_filter,
-        )
-    except Exception:
-        retrieved_sop = ""
+    if retrieved_sop_chunks is not None:
+        retrieved_sop = "\n\n---\n\n".join(chunk.text for chunk in retrieved_sop_chunks if chunk.text)
+    else:
+        try:
+            retrieved_sop_context = resolve_retrieved_sop_context(
+                transcript_text=transcript_text,
+                retrieved_sop_from_pinecone=retrieved_sop_from_pinecone,
+                org_filter=org_filter,
+            )
+            retrieved_sop = retrieved_sop_context.text
+            retrieved_sop_chunks = retrieved_sop_context.chunks
+        except Exception:
+            retrieved_sop = ""
+            retrieved_sop_chunks = []
 
-    topic_hint = _detect_topic(transcript_text, retrieved_sop)
-    expected_steps = RESOLUTION_GRAPHS.get(topic_hint, []).copy()
-    expected_steps.extend(step for step in _extract_sop_steps(retrieved_sop) if step not in expected_steps)
-    expected_steps = expected_steps[:8]
+    topic_hint = _detect_topic_from_sop_chunks(retrieved_sop_chunks or []) or _detect_topic(transcript_text, retrieved_sop)
+    extracted_sop_steps = _extract_sop_steps(retrieved_sop)
+    if extracted_sop_steps:
+        expected_steps = extracted_sop_steps[:8]
+    else:
+        expected_steps = RESOLUTION_GRAPHS.get(topic_hint, []).copy()[:8]
 
     deterministic_missing = _trajectory_missing_steps(transcript_text, expected_steps)
     deterministic_efficiency = _efficiency_score_heuristic(
@@ -777,13 +1461,16 @@ async def evaluate_process_adherence(
             evidence_quotes=evidence_quotes,
             citations=citations,
             insufficient_evidence=not bool(evidence_quotes),
+            confidence_score=None,
         )
 
     if not result.detected_topic.strip():
         result.detected_topic = topic_hint
 
-    merged_missing = list(dict.fromkeys(deterministic_missing + result.missing_sop_steps))
-    result.missing_sop_steps = merged_missing
+    result.missing_sop_steps = _merge_missing_steps(
+        deterministic_missing=deterministic_missing,
+        llm_missing=result.missing_sop_steps,
+    )
     result.efficiency_score = max(
         1,
         min(10, int(round((result.efficiency_score + deterministic_efficiency) / 2))),
@@ -801,6 +1488,10 @@ async def evaluate_process_adherence(
             result.citations.append(
                 EvidenceCitation(source="sop", speaker="system", quote=sop_quote[0])
             )
+    if result.confidence_score is None and retrieved_sop_chunks:
+        scored_chunks = [chunk.score for chunk in retrieved_sop_chunks if chunk.score is not None]
+        if scored_chunks:
+            result.confidence_score = _clamp_unit(max(scored_chunks))
     return result
 
 
@@ -836,6 +1527,8 @@ async def run_nli_policy_check(
             evidence_quotes=evidence_quotes,
             citations=citations,
             insufficient_evidence=not bool(citations),
+            confidence_score=None,
+            policy_alignment_score=None,
         )
     if not result.evidence_quotes:
         result.evidence_quotes = _quote_candidates(
@@ -855,6 +1548,14 @@ async def run_nli_policy_check(
                 EvidenceCitation(source="policy", speaker="system", quote=policy_quote[0])
             )
         result.citations = citations
+    if result.policy_alignment_score is None:
+        category = (result.nli_category or "").strip().lower()
+        if category == "entailment":
+            result.policy_alignment_score = 1.0
+        elif category == "benign deviation":
+            result.policy_alignment_score = 0.5
+        elif category in {"contradiction", "policy hallucination"}:
+            result.policy_alignment_score = 0.0
     return result
 
 
@@ -936,6 +1637,7 @@ async def _evaluate_emotion_pipeline(
 async def _evaluate_rag_pipeline(
     process_context_text: str,
     sop_context: str,
+    sop_chunks: list[RetrievedChunk],
     org_filter: str | None,
     agent_statement: str,
     policy_context: str,
@@ -944,6 +1646,7 @@ async def _evaluate_rag_pipeline(
         transcript_text=process_context_text,
         retrieved_sop_from_pinecone=sop_context,
         org_filter=org_filter,
+        retrieved_sop_chunks=sop_chunks,
     )
     nli_task = run_nli_policy_check(
         agent_statement=agent_statement,
@@ -952,13 +1655,70 @@ async def _evaluate_rag_pipeline(
     return await asyncio.gather(process_task, nli_task)
 
 
+async def _load_cached_trigger_report(
+    session: AsyncSession,
+    interaction_id: UUID,
+    org_filter: str | None,
+) -> InteractionLLMTriggerReport | None:
+    cached_result = await session.exec(
+        select(InteractionLLMTriggerCache).where(InteractionLLMTriggerCache.interaction_id == interaction_id)
+    )
+    cached = cached_result.first()
+    if not cached or not cached.report_payload:
+        return None
+    if org_filter and cached.org_filter and cached.org_filter != org_filter:
+        return None
+    try:
+        return InteractionLLMTriggerReport.model_validate(cached.report_payload)
+    except Exception:
+        logger.warning("Ignoring invalid cached LLM trigger payload for interaction %s", interaction_id, exc_info=True)
+        return None
+
+
+async def _persist_trigger_report(
+    session: AsyncSession,
+    report: InteractionLLMTriggerReport,
+    org_filter: str | None,
+    *,
+    commit: bool,
+) -> None:
+    cached_result = await session.exec(
+        select(InteractionLLMTriggerCache).where(InteractionLLMTriggerCache.interaction_id == report.interaction_id)
+    )
+    cached = cached_result.first() or InteractionLLMTriggerCache(interaction_id=report.interaction_id)
+    cached.org_filter = org_filter
+    cached.report_payload = report.model_dump(mode="json")
+    cached.computed_at = datetime.utcnow()
+    session.add(cached)
+    if commit:
+        await session.commit()
+    else:
+        await session.flush()
+
+
 async def evaluate_interaction_triggers(
     session: AsyncSession,
     interaction_id: UUID,
     retrieved_sop_from_pinecone: str = "",
     ground_truth_policy: str = "",
     org_filter: str | None = None,
+    force_rerun: bool = False,
+    commit_cache: bool = False,
 ) -> InteractionLLMTriggerReport:
+    use_cached_report = (
+        not force_rerun
+        and not retrieved_sop_from_pinecone.strip()
+        and not ground_truth_policy.strip()
+    )
+    if use_cached_report:
+        cached_report = await _load_cached_trigger_report(
+            session=session,
+            interaction_id=interaction_id,
+            org_filter=org_filter,
+        )
+        if cached_report is not None:
+            return cached_report
+
     interaction_result = await session.exec(
         select(Interaction).where(Interaction.id == interaction_id)
     )
@@ -1009,19 +1769,24 @@ async def evaluate_interaction_triggers(
         )
 
     try:
-        sop_context = resolve_retrieved_sop(
+        sop_resolution = resolve_retrieved_sop_context(
             transcript_text=transcript_text,
             retrieved_sop_from_pinecone=retrieved_sop_from_pinecone,
             org_filter=org_filter,
         )
+        sop_context = sop_resolution.text
+        sop_chunks = sop_resolution.chunks
     except Exception:
         sop_context = ""
+        sop_chunks = []
 
     policy_context = await _resolve_active_policy_context(
         session=session,
         organization_id=interaction.organization_id,
         ground_truth_policy=ground_truth_policy,
         fallback_sop=sop_context,
+        query_text=agent_statement or transcript_text,
+        org_filter=org_filter,
     )
 
     emotion_pipeline_task = _evaluate_emotion_pipeline(
@@ -1032,6 +1797,7 @@ async def evaluate_interaction_triggers(
     rag_pipeline_task = _evaluate_rag_pipeline(
         process_context_text=process_context_text,
         sop_context=sop_context,
+        sop_chunks=sop_chunks,
         org_filter=org_filter,
         agent_statement=agent_statement,
         policy_context=policy_context.text,
@@ -1083,8 +1849,29 @@ async def evaluate_interaction_triggers(
     nli_policy.policy_effective_at = policy_context.effective_at
     nli_policy.policy_category = policy_context.category
     nli_policy.conflict_resolution_applied = policy_context.conflict_resolution_applied
+    try:
+        policy_chunks = retrieve_policy_chunks(
+            query_text=agent_statement,
+            org_filter=org_filter,
+            top_k=3,
+        )
+    except Exception:
+        policy_chunks = []
+    explainability = _build_explainability_layer(
+        emotion_shift=emotion_shift,
+        process_adherence=process_adherence,
+        nli_policy=nli_policy,
+        utterances=utterances,
+        acoustic_emotion=acoustic_emotion,
+        sop_context=sop_context,
+        sop_chunks=sop_chunks,
+        policy_context=policy_context,
+        policy_chunks=policy_chunks,
+        agent_statement=agent_statement,
+        org_filter=org_filter,
+    )
 
-    return InteractionLLMTriggerReport(
+    report = InteractionLLMTriggerReport(
         interaction_id=interaction_id,
         emotion_shift=emotion_shift,
         process_adherence=process_adherence,
@@ -1093,4 +1880,15 @@ async def evaluate_interaction_triggers(
         derived_acoustic_emotion=acoustic_emotion,
         derived_fused_emotion=fused_emotion,
         derived_agent_statement=agent_statement,
+        explainability=explainability,
     )
+
+    if not retrieved_sop_from_pinecone.strip() and not ground_truth_policy.strip():
+        await _persist_trigger_report(
+            session=session,
+            report=report,
+            org_filter=org_filter,
+            commit=commit_cache,
+        )
+
+    return report

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,3 +12,4 @@ from app.models.feedback import EmotionFeedback, ComplianceFeedback  # noqa: F40
 from app.models.faq import FAQArticle, OrganizationFAQArticle  # noqa: F401
 from app.models.snapshot import AgentPerformanceSnapshot  # noqa: F401
 from app.models.query import AssistantQuery  # noqa: F401
+from app.models.llm_trigger_cache import InteractionLLMTriggerCache  # noqa: F401

--- a/backend/app/models/llm_trigger_cache.py
+++ b/backend/app/models/llm_trigger_cache.py
@@ -1,0 +1,23 @@
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, DateTime, JSON, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+
+class InteractionLLMTriggerCache(SQLModel, table=True):
+    __tablename__ = "interaction_llm_trigger_cache"
+    __table_args__ = (UniqueConstraint("interaction_id", name="uq_interaction_llm_trigger_cache_interaction"),)
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    interaction_id: UUID = Field(foreign_key="interactions.id", index=True)
+    org_filter: str | None = Field(default=None, max_length=120)
+    report_payload: dict[str, Any] = Field(
+        default_factory=dict,
+        sa_column=Column(JSON, nullable=False),
+    )
+    computed_at: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+    )

--- a/backend/tests/test_interaction_ingestion.py
+++ b/backend/tests/test_interaction_ingestion.py
@@ -12,6 +12,7 @@ from app.models.enums import JobStatus, ProcessingStatus, SpeakerRole, UserRole
 from app.models.emotion_event import EmotionEvent
 from app.models.interaction import Interaction
 from app.models.interaction_score import InteractionScore
+from app.models.llm_trigger_cache import InteractionLLMTriggerCache
 from app.models.organization import Organization
 from app.models.policy import CompanyPolicy, PolicyCompliance
 from app.models.processing import ProcessingJob
@@ -235,6 +236,13 @@ def test_reprocess_resets_artifacts_and_jobs(client, seed_org_and_auth):
             compliance_score=0.9,
         )
     )
+    session.add(
+        InteractionLLMTriggerCache(
+            interaction_id=interaction_id,
+            org_filter="nexalink",
+            report_payload={"interaction_id": str(interaction_id), "cached": True},
+        )
+    )
 
     jobs = session.exec(
         select(ProcessingJob).where(ProcessingJob.interaction_id == interaction_id)
@@ -264,6 +272,9 @@ def test_reprocess_resets_artifacts_and_jobs(client, seed_org_and_auth):
     assert session.exec(select(EmotionEvent).where(EmotionEvent.interaction_id == interaction_id)).first() is None
     assert session.exec(select(InteractionScore).where(InteractionScore.interaction_id == interaction_id)).first() is None
     assert session.exec(select(PolicyCompliance).where(PolicyCompliance.interaction_id == interaction_id)).first() is None
+    assert session.exec(
+        select(InteractionLLMTriggerCache).where(InteractionLLMTriggerCache.interaction_id == interaction_id)
+    ).first() is None
 
     updated_jobs = session.exec(
         select(ProcessingJob).where(ProcessingJob.interaction_id == interaction_id)

--- a/backend/tests/test_interactions_llm_triggers.py
+++ b/backend/tests/test_interactions_llm_triggers.py
@@ -72,3 +72,5 @@ def test_map_llm_trigger_report_contains_process_and_nli_fields():
     assert payload["processAdherence"]["missingSopSteps"] == ["Confirm account details"]
     assert payload["nliPolicy"]["nliCategory"] == "Contradiction"
     assert payload["nliPolicy"]["justification"]
+    assert payload["explainability"]["triggerAttributions"] == []
+    assert payload["explainability"]["claimProvenance"] == []

--- a/backend/tests/test_llm_trigger_service.py
+++ b/backend/tests/test_llm_trigger_service.py
@@ -3,11 +3,14 @@ from unittest.mock import patch
 
 import pytest
 
+from app.llm_trigger.retrieval import RetrievedChunk
 from app.llm_trigger.schemas import EmotionShiftAnalysis, ProcessAdherenceReport
 from app.llm_trigger.service import (
+    _build_emotion_transition_attributions,
     _build_rolling_windows,
     _detect_cross_modal_dissonance,
     _detect_topic,
+    _detect_topic_from_sop_chunks,
     _derive_llm_inputs,
     _render_window_bundle,
     _trajectory_missing_steps,
@@ -107,6 +110,19 @@ def test_topic_and_trajectory_mapping_helpers():
     assert "Close with summary and next steps" in missing
 
 
+def test_detect_topic_from_sop_chunk_reference_prefers_matched_document():
+    chunks = [
+        RetrievedChunk(
+            text="[01-refund-request-processing.pdf]\nStep 1 - Open the Call & Verify Identity",
+            metadata={"source_file": "01-refund-request-processing.pdf"},
+            source="manual",
+        )
+    ]
+
+    topic = _detect_topic_from_sop_chunks(chunks)
+    assert topic == "refund_request"
+
+
 @pytest.mark.asyncio
 async def test_evaluate_process_adherence_merges_deterministic_and_llm_steps():
     transcript = (
@@ -128,6 +144,80 @@ async def test_evaluate_process_adherence_merges_deterministic_and_llm_steps():
     assert len(result.missing_sop_steps) >= 1
     assert result.evidence_quotes
     assert result.citations
+
+
+@pytest.mark.asyncio
+async def test_evaluate_process_adherence_uses_sop_file_hint_for_topic():
+    transcript = (
+        "customer: My bill jumped after the promo expired and I want a refund.\n"
+        "agent: I can check the billing error and apply the credit timeline."
+    )
+    chunks = [
+        RetrievedChunk(
+            text="[01-refund-request-processing.pdf]\nStep 1 - Open the Call & Verify Identity\nStep 7 - Apply Credit & Communicate Timeline",
+            metadata={"source_file": "01-refund-request-processing.pdf"},
+            source="manual",
+        )
+    ]
+
+    with patch("app.llm_trigger.service.build_process_adherence_chain", return_value=_FakeProcessChain()):
+        result = await evaluate_process_adherence(
+            transcript_text=transcript,
+            retrieved_sop_from_pinecone="",
+            org_filter="nexalink",
+            retrieved_sop_chunks=chunks,
+        )
+
+    assert result.detected_topic == "refund_request"
+
+
+def test_build_emotion_transition_attributions_tracks_each_speaker_change():
+    utterances = [
+        SimpleNamespace(
+            sequence_index=0,
+            speaker_role=SimpleNamespace(value="customer"),
+            text="I am very upset about this.",
+            emotion="frustrated",
+            emotion_confidence=0.82,
+            start_time_seconds=0.0,
+            end_time_seconds=2.0,
+        ),
+        SimpleNamespace(
+            sequence_index=1,
+            speaker_role=SimpleNamespace(value="customer"),
+            text="Thank you, that helps a lot.",
+            emotion="happy",
+            emotion_confidence=0.88,
+            start_time_seconds=18.0,
+            end_time_seconds=21.0,
+        ),
+        SimpleNamespace(
+            sequence_index=2,
+            speaker_role=SimpleNamespace(value="agent"),
+            text="Let me explain the next step.",
+            emotion="neutral",
+            emotion_confidence=0.55,
+            start_time_seconds=22.0,
+            end_time_seconds=24.0,
+        ),
+        SimpleNamespace(
+            sequence_index=3,
+            speaker_role=SimpleNamespace(value="agent"),
+            text="Great, we have fully resolved it.",
+            emotion="helpful",
+            emotion_confidence=0.74,
+            start_time_seconds=30.0,
+            end_time_seconds=33.0,
+        ),
+    ]
+
+    attributions = _build_emotion_transition_attributions(utterances)
+
+    assert len(attributions) == 2
+    assert attributions[0].family == "emotion"
+    assert attributions[0].trigger_type == "Emotion Change"
+    assert "customer" in attributions[0].title.lower()
+    assert "agent" in attributions[1].title.lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_sop_retrieval.py
+++ b/backend/tests/test_sop_retrieval.py
@@ -30,6 +30,32 @@ def test_read_manual_org_sop_docs_uses_docling_converted_markdown_for_pdf(
     assert "Validate eligibility" in text
 
 
+def test_resolve_retrieved_sop_context_preserves_manual_chunk_metadata(monkeypatch, tmp_path):
+    docs_root = tmp_path / "sop-standards"
+    sop_dir = docs_root / "nexalink" / "sop-procedures"
+    sop_dir.mkdir(parents=True)
+
+    parsed_dir = docs_root / "nexalink" / "parsed-docs"
+    parsed_dir.mkdir(parents=True)
+
+    (sop_dir / "01-refund.pdf").write_bytes(b"%PDF-1.4")
+    (parsed_dir / "01-refund.md").write_text("# SOP from parsed docs", encoding="utf-8")
+
+    monkeypatch.setattr(retrieval.settings, "SOP_DOCS_ROOT", str(docs_root))
+    monkeypatch.setattr(retrieval.settings, "SOP_PARSED_DOCS_ROOT", str(docs_root))
+
+    context = retrieval.resolve_retrieved_sop_context(
+        transcript_text="customer asked for refund",
+        retrieved_sop_from_pinecone=None,
+        org_filter="nexalink",
+    )
+
+    assert context.source == "manual"
+    assert context.chunks
+    assert context.chunks[0].metadata["source_file"] == "01-refund.pdf"
+    assert "SOP from parsed docs" in context.text
+
+
 def test_read_manual_org_sop_docs_falls_back_to_direct_text_files(monkeypatch, tmp_path):
     docs_root = tmp_path / "sop-standards"
     sop_dir = docs_root / "nexalink" / "sop-procedures"
@@ -71,3 +97,37 @@ def test_resolve_retrieved_sop_prefers_manual_docs_before_qdrant(monkeypatch, tm
 
     assert "SOP from parsed docs" in resolved
     mock_retrieve.assert_not_called()
+
+
+def test_resolve_retrieved_sop_context_selects_best_matching_manual_doc(monkeypatch, tmp_path):
+    docs_root = tmp_path / "sop-standards"
+    sop_dir = docs_root / "nexalink" / "sop-procedures"
+    sop_dir.mkdir(parents=True)
+
+    parsed_dir = docs_root / "nexalink" / "parsed-docs"
+    parsed_dir.mkdir(parents=True)
+
+    (sop_dir / "01-refund-request-processing.pdf").write_bytes(b"%PDF-1.4")
+    (parsed_dir / "01-refund-request-processing.md").write_text(
+        "# Refund Request\n\n1. Verify refund eligibility.\n2. Confirm refund timeline.\n3. Close with next steps.",
+        encoding="utf-8",
+    )
+
+    (sop_dir / "02-billing-issue-resolution.pdf").write_bytes(b"%PDF-1.4")
+    (parsed_dir / "02-billing-issue-resolution.md").write_text(
+        "# Billing Issue\n\n1. Explain charge source.\n2. Confirm customer understanding.\n3. Close with follow-up path.",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(retrieval.settings, "SOP_DOCS_ROOT", str(docs_root))
+    monkeypatch.setattr(retrieval.settings, "SOP_PARSED_DOCS_ROOT", str(docs_root))
+
+    context = retrieval.resolve_retrieved_sop_context(
+        transcript_text="customer asked for a refund and the agent explained the refund timeline and goodwill credit",
+        retrieved_sop_from_pinecone=None,
+        org_filter="nexalink",
+    )
+
+    assert "01-refund-request-processing.pdf" in context.text
+    assert "02-billing-issue-resolution.pdf" not in context.text
+    assert context.chunks[0].metadata["source_file"] == "01-refund-request-processing.pdf"

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,64 @@
+# VocalMind Documentation Index
+
+This folder contains the team-facing technical documentation for the main evaluation and retrieval subsystems in VocalMind.
+
+## Start Here
+
+1. [Evidence-Anchored Explainability Layer](./explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md)
+- Unified guide for span-level trigger attribution, claim provenance, API fields, and manager Evidence Card behavior
+
+2. [LLM Trigger Feature Guide](./llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md)
+- Architecture, SOP retrieval flow, payload behavior, testing, and maintenance notes for LLM-trigger evaluation
+
+3. [RAG Overview](./rag/RAG_OVERVIEW.md)
+- Retrieval architecture, dual-collection indexing, provenance flow, and runtime components
+
+4. [RAG Ingestion Pipeline](./rag/INGESTION_PIPELINE.md)
+- Document ingestion, parsing, chunking, and indexing workflow for policy and SOP content
+
+## Documentation Areas
+
+### `explainability/`
+
+Cross-cutting documentation for the shared explainability layer that links:
+
+1. transcript spans
+2. retrieved SOP/policy evidence
+3. verdicts shown in the manager UI
+
+### `llm_trigger/`
+
+Documentation for:
+
+1. emotion-trigger analysis
+2. SOP/process-adherence reasoning
+3. NLI policy review
+4. interaction-detail explainability payload mapping
+
+### `rag/`
+
+Documentation for:
+
+1. document ingestion
+2. retrieval and synthesis
+3. compliance and answer-evaluation flows
+4. retrieval provenance surfaced to explainability consumers
+
+## Suggested Reading Paths
+
+### If you are new to the project
+
+1. Read [Evidence-Anchored Explainability Layer](./explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md)
+2. Read [LLM Trigger Feature Guide](./llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md)
+3. Read [RAG Overview](./rag/RAG_OVERVIEW.md)
+
+### If you are debugging manager call review
+
+1. Read [Evidence-Anchored Explainability Layer](./explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md)
+2. Read [LLM Trigger Feature Guide](./llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md)
+
+### If you are debugging policy retrieval or provenance
+
+1. Read [RAG Overview](./rag/RAG_OVERVIEW.md)
+2. Read [RAG Ingestion Pipeline](./rag/INGESTION_PIPELINE.md)
+3. Read [Evidence-Anchored Explainability Layer](./explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md)

--- a/docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md
+++ b/docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md
@@ -1,0 +1,403 @@
+# Evidence-Anchored Explainability Layer
+
+## Purpose
+
+The Evidence-Anchored Explainability Layer turns opaque trigger and compliance outputs into traceable manager-facing evidence cards.
+
+Instead of only returning a session-level verdict like:
+
+- `Contradiction Trigger fired`
+- `Correctness Score: 62`
+
+the system now surfaces:
+
+1. The exact transcript span that triggered review
+2. The SOP or policy clause used as the reference point
+3. The verdict produced from that comparison
+4. A short reasoning chain a supervisor can act on
+
+This layer unifies two previously separate outputs:
+
+1. Span-Level Trigger Attribution
+2. Retrieval Provenance Scoring
+
+## Why It Exists
+
+Before this layer, both evaluation paths had the same weakness:
+
+1. LLM Trigger could flag a behavioral issue without showing which utterance caused it
+2. RAG Compliance could score or judge a claim without showing which retrieved policy chunk supported the decision
+
+The explainability layer fixes that by standardizing the path:
+
+`claim or trigger -> evidence -> verdict`
+
+## Scope
+
+This layer currently covers:
+
+1. Emotion-trigger reasoning
+2. SOP/process-adherence reasoning
+3. Policy/NLI reasoning
+4. Claim-level retrieval provenance for policy-grounded compliance review
+
+It is surfaced in:
+
+1. `GET /api/v1/interactions/{interaction_id}?include_llm_triggers=true`
+2. `POST /api/v1/rag/query`
+3. The manager session detail page Evidence Card UI
+
+## Architecture
+
+```text
+Call transcript + acoustic metadata
+    -> LLM trigger chains
+    -> process adherence / NLI policy analysis
+    -> explainability mapper
+
+Policy + SOP documents
+    -> Docling parsing
+    -> chunking + Qdrant retrieval
+    -> compliance / answer checks
+    -> explainability mapper
+
+Both paths feed one manager-facing contract:
+    triggerAttributions + claimProvenance
+```
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    A["Call Transcript + Acoustic Metadata"] --> B["LLM Trigger Chains"]
+    P["Policy + SOP Documents"] --> Q["Parsing + Chunking + Qdrant Retrieval"]
+
+    B --> C["Emotion / SOP / Policy Analysis"]
+    Q --> D["Compliance / Answer Evaluation"]
+
+    C --> E["Explainability Mapper"]
+    D --> E["Explainability Mapper"]
+
+    E --> F["Trigger Attributions"]
+    E --> G["Claim Provenance"]
+
+    F --> H["Manager Evidence Card UI"]
+    G --> H["Manager Evidence Card UI"]
+
+    H --> I["Jump to Transcript Span / Audio Timestamp"]
+```
+
+This diagram shows the key idea behind the feature:
+
+1. Trigger-side reasoning and retrieval-side reasoning are generated separately
+2. Both are normalized into one explainability contract
+3. The manager UI consumes that shared contract and links it back to the original call
+
+## Core Backend Files
+
+1. `backend/app/llm_trigger/schemas.py`
+- Defines the internal explainability models:
+  - `EvidenceSpan`
+  - `PolicyReference`
+  - `TriggerAttribution`
+  - `ClaimProvenance`
+  - `EvidenceAnchoredExplainability`
+
+2. `backend/app/llm_trigger/service.py`
+- Builds explainability output during trigger evaluation
+- Joins transcript evidence, retrieval context, and verdict-specific reasoning
+
+3. `backend/app/llm_trigger/retrieval.py`
+- Provides shared retrieval helpers used by explainability paths
+- Supplies real retrieval context for SOP/policy provenance when available
+
+4. `backend/app/api/routes/interactions.py`
+- Maps internal explainability models into the frontend response contract
+- Exposes explicit response models for OpenAPI
+
+5. `backend/app/api/routes/rag.py`
+- Adds `retrieval_provenance` to standalone RAG query responses
+
+## Core Frontend Files
+
+1. `frontend/src/app/services/api.ts`
+- Declares the explainability payload types used by the UI
+
+2. `frontend/src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx`
+- Renders trigger attribution cards and claim provenance cards
+
+3. `frontend/src/app/components/manager/SessionDetail.tsx`
+- Aggregates explainability from interaction detail data
+- Wires card timestamps to audio jump targets
+
+## Main Concepts
+
+### 1. Span-Level Trigger Attribution
+
+This is used for LLM-trigger-style findings such as:
+
+1. Acoustic-transcript dissonance
+2. SOP violation
+3. Policy contradiction
+
+Each trigger card can contain:
+
+1. `triggerType`
+2. `title`
+3. `verdict`
+4. `confidence`
+5. `evidenceSpan`
+6. `policyReference`
+7. `reasoning`
+8. `evidenceChain`
+9. `supportingQuotes`
+
+### 2. Retrieval Provenance Scoring
+
+This is used for factual or compliance claims made in the call.
+
+Each claim card can contain:
+
+1. `claimText`
+2. `claimSpan`
+3. `retrievedPolicy`
+4. `semanticSimilarity`
+5. `nliVerdict`
+6. `confidence`
+7. `reasoning`
+8. `provenance`
+9. `supportingQuotes`
+
+## Interaction Detail API Surface
+
+The main explainability payload is returned from:
+
+`GET /api/v1/interactions/{interaction_id}?include_llm_triggers=true`
+
+Relevant response fields:
+
+### Transcript anchoring
+
+1. `utterances[].sequenceIndex`
+- Stable utterance index for evidence cards
+
+2. `utterances[].startTime`
+3. `utterances[].endTime`
+4. `utterances[].timestamp`
+
+These support UI jump-to-audio behavior.
+
+### Explainability containers
+
+1. `emotionTriggers.explainability.triggerAttributions`
+2. `ragCompliance.explainability.triggerAttributions`
+3. `ragCompliance.explainability.claimProvenance`
+4. `llmTriggers.explainability`
+
+`llmTriggers.explainability` is the combined manager-facing aggregation used by the current session-detail UI.
+
+## API Payload Diagram
+
+```mermaid
+flowchart TD
+    A["GET /api/v1/interactions/{interaction_id}?include_llm_triggers=true"] --> B["interaction"]
+    A --> C["utterances[]"]
+    A --> D["emotionTriggers.explainability"]
+    A --> E["ragCompliance.explainability"]
+    A --> F["llmTriggers.explainability"]
+
+    C --> C1["sequenceIndex"]
+    C --> C2["timestamp"]
+    C --> C3["startTime / endTime"]
+
+    D --> D1["triggerAttributions[]"]
+    E --> E1["triggerAttributions[]"]
+    E --> E2["claimProvenance[]"]
+
+    F --> F1["triggerAttributions[]"]
+    F --> F2["claimProvenance[]"]
+
+    F1 --> G["evidenceSpan"]
+    F1 --> H["policyReference"]
+    F1 --> I["reasoning + evidenceChain"]
+
+    F2 --> J["claimSpan"]
+    F2 --> K["retrievedPolicy"]
+    F2 --> L["semanticSimilarity + nliVerdict + provenance"]
+```
+
+This payload view highlights the important implementation detail:
+
+1. utterances provide the stable timing and indexing anchors
+2. emotion and RAG paths each produce explainability artifacts
+3. `llmTriggers.explainability` is the merged manager-facing contract used by the UI
+
+## Response Shape
+
+### Trigger attribution
+
+```json
+{
+  "attributionId": "sop-identity-1",
+  "family": "sop",
+  "triggerType": "SOP Violation",
+  "title": "Identity Verification",
+  "verdict": "Contradiction",
+  "confidence": 0.74,
+  "evidenceSpan": {
+    "utteranceIndex": 12,
+    "speaker": "agent",
+    "quote": "Let me pull up your account.",
+    "timestamp": "01:43",
+    "startSeconds": 103.0,
+    "endSeconds": 106.0
+  },
+  "policyReference": {
+    "source": "sop",
+    "reference": "Identity SOP",
+    "clause": "Agent must ask for full name and date of birth before account lookup.",
+    "version": "v2.3",
+    "category": "Verification",
+    "provenance": "parsed-docs/identity.md > Verification Steps"
+  },
+  "reasoning": "The agent proceeded to account lookup before collecting the required credentials.",
+  "evidenceChain": [
+    "Customer requested account help.",
+    "Agent initiated lookup language.",
+    "No verification step was detected before the lookup attempt."
+  ],
+  "supportingQuotes": [
+    "Let me pull up your account."
+  ]
+}
+```
+
+### Claim provenance
+
+```json
+{
+  "claimId": "refund-claim-1",
+  "claimText": "Your refund will arrive within 24 hours.",
+  "claimSpan": {
+    "utteranceIndex": 22,
+    "speaker": "agent",
+    "quote": "Your refund will arrive within 24 hours.",
+    "timestamp": "03:17",
+    "startSeconds": 197.0,
+    "endSeconds": 200.0
+  },
+  "retrievedPolicy": {
+    "source": "policy",
+    "reference": "Refunds Policy v2.3",
+    "clause": "Standard refunds take 3-5 business days.",
+    "version": "v2.3",
+    "category": "Refund Timelines",
+    "provenance": "children chunk #47 > parent section Refund Timelines"
+  },
+  "semanticSimilarity": 0.81,
+  "nliVerdict": "Contradiction",
+  "confidence": 0.80,
+  "reasoning": "The promise conflicts with the active refund timeline in the retrieved policy.",
+  "provenance": "Refunds Policy v2.3 > Refund Timelines > chunk 47",
+  "supportingQuotes": [
+    "Your refund will arrive within 24 hours."
+  ]
+}
+```
+
+## Standalone RAG API Surface
+
+The standalone RAG route returns lightweight provenance on:
+
+`POST /api/v1/rag/query`
+
+Response field:
+
+1. `retrieval_provenance`
+
+Each item contains:
+
+1. `claim`
+2. `chunkRank`
+3. `semanticSimilarity`
+4. `verdict`
+5. `reference`
+6. `excerpt`
+7. `provenance`
+
+This route is simpler than the interaction-detail explainability contract, but it exposes the same core idea: retrieved evidence should be visible, not hidden behind a score.
+
+## Frontend Behavior
+
+The manager Evidence Card UI currently:
+
+1. Groups trigger cards under `Span-Level Trigger Attribution`
+2. Groups claim cards under `Retrieval Provenance Scoring`
+3. Shows confidence and verdict badges
+4. Displays the evidence quote and policy/SOP clause side by side
+5. Lets the user jump from a card timestamp back into audio playback
+
+The page also counts evidence cards in the session hero so supervisors can immediately see whether a call has traceable findings.
+
+## Real Signals vs Fallbacks
+
+The implementation prefers real pipeline signals whenever they are available.
+
+Currently supported:
+
+1. Real utterance span anchoring from transcript timing
+2. Real retrieval provenance from retrieved policy/SOP context
+3. Real model-reported confidence for supported trigger paths when available
+4. Real similarity values from retrieved chunks where the retrieval layer exposes scores
+
+When a score is not available, the frontend shows `N/A` instead of inventing a value.
+
+## Testing
+
+Current tests that cover this layer:
+
+1. `backend/tests/test_interactions_llm_triggers.py`
+- Verifies explainability fields are mapped into the API payload
+
+2. `backend/tests/test_sop_retrieval.py`
+- Verifies SOP retrieval context used by explainability paths
+
+3. `frontend/src/tests/SessionDetail.test.tsx`
+- Verifies evidence cards render in the manager session detail page
+
+4. `frontend/src/tests/LLMTriggerSections.test.tsx`
+- Verifies trigger sections and explainability-related manager detail rendering
+
+## Suggested Evaluation for the Project Report
+
+If this layer is presented as a research contribution, the recommended evaluation is:
+
+1. Have 2-3 human supervisors annotate a set of call segments
+2. Record:
+- which utterance span they would flag
+- why they flagged it
+- which policy/SOP clause they used
+
+3. Compare system output against human annotations using:
+- span-level F1
+- qualitative reasoning agreement
+- correlation between provenance-backed claim verdicts and human compliance judgments
+
+## Known Limitations
+
+1. Explainability quality still depends on transcript quality and retrieval quality
+2. Some confidence values depend on whether the underlying chain exposes model confidence
+3. The standalone RAG route currently returns a lightweight provenance shape, not the full interaction-detail explainability model
+4. Human evaluation is not yet automated in the repo and should be run as a separate study workflow
+
+## Recommended Maintenance Workflow
+
+When changing trigger logic, retrieval logic, or evidence-card UI:
+
+1. Update the schema in `backend/app/llm_trigger/schemas.py` if the contract changes
+2. Update the route response models in `backend/app/api/routes/interactions.py`
+3. Update frontend types in `frontend/src/app/services/api.ts`
+4. Update the Evidence Card renderer in `frontend/src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx`
+5. Re-run the targeted backend and frontend tests that cover explainability
+
+This keeps the implementation, OpenAPI contract, and manager UI aligned.

--- a/docs/llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md
+++ b/docs/llm_trigger/LLM_TRIGGER_FEATURE_GUIDE.md
@@ -10,6 +10,23 @@ The LLM Trigger feature evaluates customer-agent interactions and returns coachi
 
 This guide documents architecture, data flow, folder structure, runtime behavior, and testing so the team can maintain and extend the feature safely.
 
+## Evidence-Anchored Explainability
+
+The trigger pipeline now emits a shared explainability layer instead of returning only session-level verdicts.
+
+Manager-facing output is split into:
+
+1. Span-Level Trigger Attribution
+- Anchors emotion, SOP, and policy triggers to a specific utterance span.
+- Adds `evidenceSpan`, `policyReference`, `reasoning`, and `evidenceChain`.
+- Uses the same payload family for both emotion-trigger and RAG-driven findings.
+
+2. Retrieval Provenance Scoring
+- Anchors factual or compliance claims to the retrieved policy/SOP chunk used for review.
+- Adds `claimSpan`, `retrievedPolicy`, `semanticSimilarity`, `nliVerdict`, and `provenance`.
+
+See `docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md` for the full shared contract.
+
 ## High-Level Architecture
 
 1. Backend interaction detail endpoint can request LLM trigger evaluation.
@@ -19,6 +36,7 @@ This guide documents architecture, data flow, folder structure, runtime behavior
    - Qdrant retrieval fallback
 4. Results are mapped into a frontend-friendly payload.
 5. Manager and Agent views render diagnostics and coaching insights.
+6. Manager detail view renders evidence cards that connect claim -> evidence -> verdict.
 
 ## Core Backend Files
 
@@ -55,8 +73,13 @@ This guide documents architecture, data flow, folder structure, runtime behavior
 2. `frontend/src/app/components/manager/SessionDetail.tsx`
 - Renders manager-focused trigger diagnostics.
 - Supports LLM refresh action.
+- Hosts the Evidence-Anchored Explainability panel.
 
-3. `frontend/src/app/components/agent/AgentCallDetail.tsx`
+3. `frontend/src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx`
+- Renders trigger attribution cards and claim provenance cards.
+- Supports timestamp jump-to-audio interactions.
+
+4. `frontend/src/app/components/agent/AgentCallDetail.tsx`
 - Renders coaching-focused trigger insights.
 - Supports LLM refresh action.
 
@@ -128,6 +151,25 @@ Interaction detail supports these query options:
 
 If `llm_org_filter` is omitted, backend resolves org slug from interaction -> organization relation.
 
+## Explainability Payload Surface
+
+The interaction detail response now exposes:
+
+1. `utterances[].sequenceIndex`
+- Stable utterance index used by evidence cards.
+
+2. `emotionTriggers.explainability.triggerAttributions`
+- Emotion-side span attributions.
+
+3. `ragCompliance.explainability.triggerAttributions`
+- SOP and policy trigger attributions derived from compliance review.
+
+4. `ragCompliance.explainability.claimProvenance`
+- Claim-level retrieval provenance for policy-grounded verdicts.
+
+5. `llmTriggers.explainability`
+- Combined manager-friendly aggregation of all trigger attributions plus claim provenance.
+
 ## Retrieval Priority
 
 When process adherence analysis needs SOP context:
@@ -175,6 +217,7 @@ This runs:
 
 2. `test_interactions_llm_triggers.py`
 - API payload mapper shape and field mapping
+- Includes explainability mapping assertions
 
 3. `test_sop_retrieval.py`
 - PDF-first SOP retrieval from parsed docs
@@ -191,6 +234,9 @@ This runs:
 
 1. `LLMTriggerSections.test.tsx`
 - Manager and Agent views render trigger sections correctly
+
+2. `SessionDetail.test.tsx`
+- Manager detail page renders evidence-anchored explainability cards and provenance details
 
 ## Operational Runbook
 

--- a/docs/llm_trigger/README.md
+++ b/docs/llm_trigger/README.md
@@ -7,7 +7,10 @@ This folder is intentionally minimal.
 1. `LLM_TRIGGER_FEATURE_GUIDE.md`
 	- Single comprehensive guide for architecture, data flow, SOP/PDF flow, API behavior, testing, and troubleshooting.
 
-2. `README.md`
+2. `../explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md`
+	- Shared contract for span-level trigger attribution, claim provenance, API fields, and manager Evidence Card behavior.
+
+3. `README.md`
 	- This index and usage note.
 
 ## Test source of truth

--- a/docs/rag/RAG_OVERVIEW.md
+++ b/docs/rag/RAG_OVERVIEW.md
@@ -10,6 +10,8 @@ It combines:
 3. Qdrant vector search (dual collections)
 4. Groq LLM synthesis
 
+It also now feeds the Evidence-Anchored Explainability Layer used in manager call review.
+
 ## Key Concepts
 
 1. Dual-granularity indexing
@@ -23,6 +25,11 @@ It combines:
 3. Query modes
 - Compliance mode queries parent chunks
 - Answer mode queries child chunks
+
+4. Retrieval provenance
+- Retrieved chunks can be surfaced with similarity, reference path, and lightweight verdict metadata.
+- Interaction detail pages expose this through `claimProvenance`.
+- The standalone RAG route exposes `retrieval_provenance`.
 
 ## Main Runtime Components
 
@@ -38,6 +45,10 @@ It combines:
 
 3. `services/rag/config.py`
 - Central settings for model, endpoints, collections, and paths
+
+4. `backend/app/api/routes/rag.py`
+- Wraps RAG results for the frontend API.
+- Returns `retrieval_provenance` on `/api/v1/rag/query`.
 
 ## Collections
 
@@ -85,7 +96,8 @@ It combines:
 1. Ingestion parses PDFs and indexes vectors
 2. Query engine retrieves relevant chunks
 3. Groq synthesizes response from retrieved context
-4. Logs and timing are stored for auditability
+4. Retrieval provenance is attached for explainability and auditability
+5. Logs and timing are stored for auditability
 
 ## Testing
 
@@ -94,6 +106,8 @@ Primary tests:
 2. `services/rag/tests/test_query_engine.py`
 3. `services/rag/tests/test_evaluator.py`
 4. `services/rag/tests/test_config.py`
+5. `backend/tests/test_interactions_llm_triggers.py`
+6. `backend/tests/test_sop_retrieval.py`
 
 Run:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,61 @@
+# VocalMind Frontend
 
-  # Implement Idea
+Manager and agent web UI for VocalMind, built with React 18, Vite, Tailwind v4, MUI, and Radix UI.
 
-  This is a code bundle for Implement Idea. The original project is available at https://www.figma.com/design/b96C1zvBIwHeR0FqVemufc/Implement-Idea.
+## Main Areas
 
-  ## Running the code
+1. Manager dashboard and session inspector
+2. Call detail pages with transcript playback and evaluation panels
+3. Knowledge-base management
+4. Assistant and agent-facing workflows
 
-  Run `npm i` to install the dependencies.
+## Explainability UI
 
-  Run `npm run dev` to start the development server.
-  
+The manager session-detail page now includes the Evidence-Anchored Explainability panel.
+
+It renders:
+
+1. Span-Level Trigger Attribution cards
+2. Retrieval Provenance Scoring cards
+3. Timestamp jump actions that sync cards back to audio playback
+
+See `docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md` for the full feature contract.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the dev server:
+
+```bash
+npm run dev
+```
+
+Type-check:
+
+```bash
+npm run lint
+```
+
+Run tests:
+
+```bash
+npm run test
+```
+
+## Relevant Files
+
+1. `src/app/components/manager/SessionInspector.tsx`
+2. `src/app/components/manager/SessionDetail.tsx`
+3. `src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx`
+4. `src/app/services/api.ts`
+
+## Targeted UI Tests
+
+1. `src/tests/SessionInspector.test.tsx`
+2. `src/tests/SessionDetail.test.tsx`
+3. `src/tests/LLMTriggerSections.test.tsx`

--- a/frontend/cypress/e2e/session-inspector.cy.ts
+++ b/frontend/cypress/e2e/session-inspector.cy.ts
@@ -5,25 +5,23 @@ describe("Session Inspector", () => {
 
   it("renders the page heading and subtitle", () => {
     cy.contains("h2", "Session Inspector");
-    cy.contains(/interaction(s)? found/i);
+    cy.contains(/Review live processing/i);
   });
 
   it("displays search input and filter controls", () => {
-    cy.get('input[placeholder="Search agent, date, ID…"]').should("exist");
+    cy.get('input[placeholder="Search agent, date, ID..."]').should("exist");
     cy.get("select").find("option").contains("All Agents");
-    cy.contains("button", /score\s*↓/i);
+    cy.contains("button", /score/i);
     cy.contains("button", /date/i);
     cy.contains("button", /duration/i);
   });
 
   it("renders table headers", () => {
     cy.contains("Agent");
-    cy.contains("Date & Time");
+    cy.contains(/Date and time/i);
     cy.contains("Duration");
     cy.contains("Score");
-    cy.contains("Empathy");
-    cy.contains("Policy");
-    cy.contains("Resolution");
+    cy.contains("Signals");
     cy.contains("Status");
     cy.contains("Actions");
   });
@@ -37,24 +35,24 @@ describe("Session Inspector", () => {
   });
 
   it("displays resolved and unresolved statuses", () => {
-    cy.contains("✓ Resolved");
-    cy.contains("✗ Unresolved");
+    cy.contains("Resolved");
+    cy.contains("Needs review");
   });
 
   it("shows violation badges for flagged interactions", () => {
-    cy.contains("⚠ Violation");
+    cy.contains("Violation");
   });
 
   it("has Inspect links that navigate to session detail", () => {
-    cy.contains("a", "Inspect →").first().click();
+    cy.contains("a", /^Inspect$/).first().click();
     cy.url().should("match", /\/manager\/inspector\/.+/);
   });
 
   it("displays pagination footer", () => {
-    cy.contains(/Showing 1–\d+ of \d+/);
-    cy.contains("button", "← Prev").should("be.disabled");
+    cy.contains(/Showing\s+\d+\s+to\s+\d+\s+of\s+\d+/);
+    cy.contains("button", "Prev").should("be.disabled");
     // Based on whether there's more than 10 mock interactions 
     // it could be disabled or not. Let's just check it exists.
-    cy.contains("button", "Next →").should("exist");
+    cy.contains("button", "Next").should("exist");
   });
 });

--- a/frontend/src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx
+++ b/frontend/src/app/components/manager/EvidenceAnchoredExplainabilityPanel.tsx
@@ -1,0 +1,437 @@
+import { useMemo, useState, type ReactNode } from "react";
+import type {
+  ClaimProvenance,
+  EvidenceAnchoredExplainability,
+  TriggerAttribution,
+} from "../../services/api";
+
+const verdictTheme: Record<string, string> = {
+  Supported: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  "Partial Attempt": "bg-amber-50 text-amber-700 border-amber-200",
+  Neutral: "bg-slate-100 text-slate-700 border-slate-200",
+  Contradiction: "bg-rose-50 text-rose-700 border-rose-200",
+  "Cross-Modal Mismatch": "bg-purple-50 text-purple-700 border-purple-200",
+  "No Trigger": "bg-sky-50 text-sky-700 border-sky-200",
+  "Insufficient Evidence": "bg-slate-100 text-slate-500 border-slate-200",
+};
+
+function formatPercent(value?: number | null): string {
+  const numeric = Number(value);
+  if (value == null || !Number.isFinite(numeric)) {
+    return "N/A";
+  }
+  return `${Math.round(Math.max(0, Math.min(1, numeric)) * 100)}%`;
+}
+
+function cleanEvidenceText(value?: string | null): string {
+  return (value || "")
+    .replace(/\r/g, "")
+    .replace(/^\s*#{1,6}\s*/gm, "")
+    .replace(/<!--.*?-->/gs, " ")
+    .replace(/\s*Ã¢â‚¬Â¢\s*/g, " / ")
+    .replace(/\s*â€¢\s*/g, " / ")
+    .replace(/\|{2,}/g, " / ")
+    .replace(/[-|]{4,}/g, " ")
+    .replace(/^\s*[-*]\s+/gm, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+function VerdictBadge({ verdict }: { verdict: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wider ${
+        verdictTheme[verdict] || verdictTheme.Neutral
+      }`}
+    >
+      {verdict}
+    </span>
+  );
+}
+
+function JumpButton({
+  timestamp,
+  startSeconds,
+  onJumpTo,
+}: {
+  timestamp?: string | null;
+  startSeconds?: number | null;
+  onJumpTo?: (seconds: number) => void;
+}) {
+  if (!onJumpTo || startSeconds == null) {
+    return timestamp ? <span className="text-[11px] font-bold text-slate-400">{timestamp}</span> : null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onJumpTo(startSeconds)}
+      className="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wider text-slate-600 transition-colors hover:border-primary hover:text-primary"
+    >
+      {timestamp || "Jump"}
+    </button>
+  );
+}
+
+function Pager({
+  count,
+  index,
+  onChange,
+}: {
+  count: number;
+  index: number;
+  onChange: (next: number) => void;
+}) {
+  if (count <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onChange(Math.max(0, index - 1))}
+        disabled={index === 0}
+        className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[10px] font-extrabold uppercase tracking-wider text-slate-600 disabled:opacity-40"
+      >
+        Prev
+      </button>
+      <span className="text-[10px] font-extrabold uppercase tracking-wider text-slate-400">
+        {index + 1} / {count}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(Math.min(count - 1, index + 1))}
+        disabled={index === count - 1}
+        className="rounded-full border border-slate-200 bg-white px-3 py-1 text-[10px] font-extrabold uppercase tracking-wider text-slate-600 disabled:opacity-40"
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
+function TriggerCard({
+  attribution,
+  onJumpTo,
+}: {
+  attribution: TriggerAttribution;
+  onJumpTo?: (seconds: number) => void;
+}) {
+  return (
+    <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-extrabold uppercase tracking-[0.24em] text-slate-400">
+            {cleanEvidenceText(attribution.triggerType)}
+          </p>
+          <h4 className="mt-1 text-[18px] font-extrabold text-slate-900">
+            {cleanEvidenceText(attribution.title)}
+          </h4>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wider text-slate-600">
+            Confidence {formatPercent(attribution.confidence)}
+          </span>
+          <VerdictBadge verdict={attribution.verdict} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+        <div className="space-y-3">
+          {attribution.evidenceSpan && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-500">
+                  Evidence Span
+                  {attribution.evidenceSpan.speaker
+                    ? ` - ${cleanEvidenceText(attribution.evidenceSpan.speaker)}`
+                    : ""}
+                </p>
+                <JumpButton
+                  timestamp={attribution.evidenceSpan.timestamp}
+                  startSeconds={attribution.evidenceSpan.startSeconds}
+                  onJumpTo={onJumpTo}
+                />
+              </div>
+              <p className="mt-2 text-[13px] italic leading-relaxed text-slate-700">
+                &ldquo;{cleanEvidenceText(attribution.evidenceSpan.quote)}&rdquo;
+              </p>
+            </div>
+          )}
+
+          {attribution.policyReference && (
+            <div className="rounded-xl border border-orange-200 bg-orange-50 p-3">
+              <p className="text-[11px] font-extrabold uppercase tracking-wider text-orange-700">
+                {attribution.policyReference.source === "sop" ? "SOP Clause" : "Policy Clause"}
+              </p>
+              <p className="mt-1 text-[12px] font-bold text-orange-900">
+                {cleanEvidenceText(attribution.policyReference.reference)}
+              </p>
+              <p className="mt-2 text-[13px] leading-relaxed text-orange-900/80">
+                {cleanEvidenceText(attribution.policyReference.clause)}
+              </p>
+              {attribution.policyReference.provenance && (
+                <p className="mt-2 text-[11px] font-medium text-orange-800/70">
+                  {cleanEvidenceText(attribution.policyReference.provenance)}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3">
+          <div className="rounded-xl border border-slate-200 bg-white p-3">
+            <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-500">Reasoning</p>
+            <div className="mt-2 max-h-[15rem] overflow-y-auto pr-1 text-[13px] leading-relaxed text-slate-700">
+              {cleanEvidenceText(attribution.reasoning)}
+            </div>
+          </div>
+
+          {attribution.evidenceChain.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+              <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-500">Evidence Chain</p>
+              <div className="mt-2 space-y-2">
+                {attribution.evidenceChain.map((step) => (
+                  <div key={step} className="rounded-xl bg-white px-3 py-2 text-[12px] font-medium text-slate-600">
+                    {cleanEvidenceText(step)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ClaimCard({
+  claim,
+  onJumpTo,
+}: {
+  claim: ClaimProvenance;
+  onJumpTo?: (seconds: number) => void;
+}) {
+  return (
+    <article className="rounded-2xl border border-teal-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] font-extrabold uppercase tracking-[0.24em] text-teal-600">
+            Claim Provenance
+          </p>
+          <h4 className="mt-1 text-[18px] font-extrabold text-slate-900">
+            {cleanEvidenceText(claim.claimText)}
+          </h4>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full bg-teal-50 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-wider text-teal-700">
+            Similarity {formatPercent(claim.semanticSimilarity)}
+          </span>
+          <VerdictBadge verdict={claim.nliVerdict} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+        <div className="space-y-3">
+          {claim.claimSpan && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-500">
+                  Agent Claim
+                </p>
+                <JumpButton
+                  timestamp={claim.claimSpan.timestamp}
+                  startSeconds={claim.claimSpan.startSeconds}
+                  onJumpTo={onJumpTo}
+                />
+              </div>
+              <p className="mt-2 text-[13px] italic leading-relaxed text-slate-700">
+                &ldquo;{cleanEvidenceText(claim.claimSpan.quote)}&rdquo;
+              </p>
+            </div>
+          )}
+
+          {claim.retrievedPolicy && (
+            <div className="rounded-xl border border-teal-200 bg-teal-50 p-3">
+              <p className="text-[11px] font-extrabold uppercase tracking-wider text-teal-700">
+                Retrieved Policy
+              </p>
+              <p className="mt-1 text-[12px] font-bold text-teal-900">
+                {cleanEvidenceText(claim.retrievedPolicy.reference)}
+              </p>
+              <p className="mt-2 text-[13px] leading-relaxed text-teal-900/80">
+                {cleanEvidenceText(claim.retrievedPolicy.clause)}
+              </p>
+              <p className="mt-2 text-[11px] font-medium text-teal-800/70">
+                {cleanEvidenceText(claim.provenance)}
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-xl border border-slate-200 bg-white p-3">
+          <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-500">Reasoning</p>
+          <div className="mt-2 max-h-[15rem] overflow-y-auto pr-1 text-[13px] leading-relaxed text-slate-700">
+            {cleanEvidenceText(claim.reasoning)}
+          </div>
+          <p className="mt-4 text-[11px] font-bold uppercase tracking-wider text-slate-400">
+            Confidence {formatPercent(claim.confidence)}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function PagedSection({
+  sectionKey,
+  title,
+  accent,
+  count,
+  index,
+  onChange,
+  cardKey,
+  children,
+}: {
+  sectionKey: string;
+  title: string;
+  accent: string;
+  count: number;
+  index: number;
+  onChange: (next: number) => void;
+  cardKey: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <p className={`text-[11px] font-extrabold uppercase tracking-[0.24em] ${accent}`}>{title}</p>
+        <Pager count={count} index={index} onChange={onChange} />
+      </div>
+      <div
+        key={`${sectionKey}-${cardKey}`}
+        style={{ animation: "evidenceCardTurn 320ms cubic-bezier(0.22, 1, 0.36, 1)" }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function EvidenceAnchoredExplainabilityPanel({
+  explainability,
+  onJumpTo,
+}: {
+  explainability?: EvidenceAnchoredExplainability | null;
+  onJumpTo?: (seconds: number) => void;
+}) {
+  const triggerAttributions = explainability?.triggerAttributions ?? [];
+  const claimProvenance = explainability?.claimProvenance ?? [];
+  const [pages, setPages] = useState<Record<string, number>>({});
+  const [activeSection, setActiveSection] = useState<string>("");
+
+  const grouped = useMemo(
+    () => ({
+      sop: triggerAttributions.filter((item) => item.family === "sop"),
+      policy: triggerAttributions.filter((item) => item.family === "policy"),
+      emotion: triggerAttributions.filter((item) => item.family === "emotion"),
+      claims: claimProvenance,
+    }),
+    [claimProvenance, triggerAttributions],
+  );
+
+  const sections = useMemo(
+    () =>
+      [
+        { key: "sop", title: "SOP Violations", accent: "text-orange-300", items: grouped.sop, kind: "trigger" as const },
+        { key: "policy", title: "Policy Findings", accent: "text-rose-300", items: grouped.policy, kind: "trigger" as const },
+        { key: "emotion", title: "Span-Level Trigger Attribution", accent: "text-purple-300", items: grouped.emotion, kind: "trigger" as const },
+        { key: "claims", title: "Retrieval Provenance Scoring", accent: "text-teal-300", items: grouped.claims, kind: "claim" as const },
+      ].filter((section) => section.items.length > 0),
+    [grouped],
+  );
+
+  if (!triggerAttributions.length && !claimProvenance.length) {
+    return null;
+  }
+
+  const getIndex = (key: string, count: number) => Math.min(pages[key] ?? 0, Math.max(0, count - 1));
+  const setIndex = (key: string, next: number) => setPages((current) => ({ ...current, [key]: next }));
+  const currentSection = sections.find((section) => section.key === activeSection) || sections[0];
+  const currentIndex = getIndex(currentSection.key, currentSection.items.length);
+  const currentItem = currentSection.items[currentIndex];
+
+  return (
+    <section className="rounded-[24px] border border-slate-200 bg-[linear-gradient(180deg,#0F172A_0%,#111827_110%)] p-6 shadow-sm">
+      <style>
+        {`
+          @keyframes evidenceCardTurn {
+            0% {
+              opacity: 0;
+              transform: perspective(1100px) rotateY(-10deg) translateY(8px) scale(0.985);
+            }
+            100% {
+              opacity: 1;
+              transform: perspective(1100px) rotateY(0deg) translateY(0) scale(1);
+            }
+          }
+        `}
+      </style>
+
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-[11px] font-extrabold uppercase tracking-[0.26em] text-orange-300">
+            Evidence-Anchored Explainability
+          </p>
+          <h3 className="mt-2 text-[20px] font-extrabold text-white">Claim to evidence to verdict</h3>
+          <p className="mt-1 max-w-2xl text-[13px] leading-relaxed text-slate-300">
+            Findings are grouped by type and shown as a compact review deck, so supervisors can page through evidence without growing the page into a long scroll.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-[11px] font-bold uppercase tracking-wider text-slate-300">
+          {triggerAttributions.length} trigger cards / {claimProvenance.length} provenance cards
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-4">
+        <div className="flex flex-wrap gap-2">
+          {sections.map((section) => {
+            const isActive = section.key === currentSection.key;
+            return (
+              <button
+                key={section.key}
+                type="button"
+                onClick={() => setActiveSection(section.key)}
+                className={`rounded-full border px-3 py-2 text-[11px] font-extrabold uppercase tracking-[0.18em] transition-colors ${
+                  isActive
+                    ? "border-white/30 bg-white/14 text-white"
+                    : "border-white/10 bg-white/5 text-slate-300 hover:border-white/20 hover:text-white"
+                }`}
+              >
+                {section.title} ({section.items.length})
+              </button>
+            );
+          })}
+        </div>
+
+        <PagedSection
+          sectionKey={currentSection.key}
+          title={currentSection.title}
+          accent={currentSection.accent}
+          count={currentSection.items.length}
+          index={currentIndex}
+          onChange={(next) => setIndex(currentSection.key, next)}
+          cardKey={`${currentSection.key}-${currentIndex}`}
+        >
+          {currentSection.kind === "claim" ? (
+            <ClaimCard claim={currentItem as ClaimProvenance} onJumpTo={onJumpTo} />
+          ) : (
+            <TriggerCard attribution={currentItem as TriggerAttribution} onJumpTo={onJumpTo} />
+          )}
+        </PagedSection>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/app/components/manager/SessionDetail.tsx
+++ b/frontend/src/app/components/manager/SessionDetail.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router";
 import { ArrowLeft, Play, Headphones, Loader2, AlertTriangle as AlertTriangleIcon } from "lucide-react";
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { getInteractionDetail, getAudioUrl, reprocessInteraction, type InteractionDetail } from "../../services/api";
+import { EvidenceAnchoredExplainabilityPanel } from "./EvidenceAnchoredExplainabilityPanel";
 
 const emotionTheme: Record<string, { label: string; color: string; surface: string }> = {
   neutral: { label: "Neutral", color: "#64748B", surface: "rgba(100, 116, 139, 0.16)" },
@@ -299,6 +300,19 @@ export function SessionDetail() {
     return null;
   }, [data]);
 
+  const explainability = useMemo(() => {
+    if (data?.llmTriggers?.explainability) {
+      return data.llmTriggers.explainability;
+    }
+    return {
+      triggerAttributions: [
+        ...(emotionTriggers?.explainability?.triggerAttributions || []),
+        ...(ragCompliance?.explainability?.triggerAttributions || []),
+      ],
+      claimProvenance: ragCompliance?.explainability?.claimProvenance || [],
+    };
+  }, [data, emotionTriggers, ragCompliance]);
+
   const handleJumpTo = (seconds: number) => {
     if (audioRef.current) {
       audioRef.current.currentTime = seconds;
@@ -486,6 +500,23 @@ export function SessionDetail() {
       : interactionStatus === "completed"
         ? "border-emerald-200 text-emerald-700 bg-emerald-50"
         : "border-slate-200 text-slate-600 bg-slate-100";
+  const explainabilityCardCount =
+    (explainability?.triggerAttributions?.length || 0) + (explainability?.claimProvenance?.length || 0);
+  const reviewSignals = [
+    { label: "Utterances", value: `${utterances.length}` },
+    { label: "Evidence cards", value: `${explainabilityCardCount}` },
+    { label: "Policy flags", value: `${policyCards.length}` },
+  ];
+  const processingSteps = [
+    { label: "Transcription", done: !isProcessing || utterances.length > 0 },
+    { label: "Explainability", done: !isProcessing || explainabilityCardCount > 0 },
+    { label: "Compliance", done: !isProcessing || Boolean(ragCompliance?.available) },
+  ];
+  const sessionNarrative = isProcessing
+    ? "This call is still moving through the evaluation pipeline. The page will refresh automatically as transcript, explainability, and policy analysis become available."
+    : explainabilityCardCount > 0
+      ? "This session now includes evidence-backed explainability, so supervisors can move from a score to the exact span and policy evidence behind it."
+      : "This session summary is ready. Use the transcript, evaluation cards, and evidence panel to review the conversation from playback through policy reasoning.";
 
   const handleProgressChange = (value: number) => {
     if (!audioRef.current) {
@@ -500,7 +531,7 @@ export function SessionDetail() {
   return (
     <div className="p-4 md:p-8 space-y-6 max-w-[1600px] mx-auto bg-[#F8FAFC] dark:bg-[#090B10] min-h-screen text-slate-900 dark:text-slate-100">
       {/* Top Navigation */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <Link
           to="/manager/inspector"
           className="inline-flex items-center gap-2 text-[14px] font-semibold text-slate-500 dark:text-slate-300 hover:text-primary transition-colors"
@@ -508,7 +539,7 @@ export function SessionDetail() {
           <ArrowLeft className="w-4 h-4" />
           Back to Sessions
         </Link>
-        <div className="flex items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
           {interactionStatus && (
             <div className={`px-3 py-1.5 rounded-full text-[11px] font-bold uppercase tracking-wider border ${statusBadgeClass}`}>
               {interactionStatus}
@@ -535,103 +566,159 @@ export function SessionDetail() {
       )}
 
       {/* Top Header Card */}
-      <div className="bg-white dark:bg-slate-900 rounded-2xl border border-border dark:border-slate-700 p-8 shadow-sm flex flex-col xl:flex-row justify-between items-start xl:items-center gap-8">
-        <div>
-          <h2 className="text-[28px] font-extrabold text-slate-900 dark:text-slate-100 mb-2 tracking-tight">
-            {interaction.agentName}
-          </h2>
-          <div className="text-[13px] text-slate-500 dark:text-slate-300 font-medium flex items-center gap-3">
-            <span>{interaction.date}</span>
-            <span className="w-1 h-1 rounded-full bg-slate-300"></span>
-            <span>{interaction.time}</span>
-            <span className="w-1 h-1 rounded-full bg-slate-300"></span>
-            <span>{interaction.duration}</span>
-            <span className="w-1 h-1 rounded-full bg-slate-300"></span>
-            <span className="uppercase">{interaction.language}</span>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-8 xl:gap-12 w-full xl:w-auto overflow-x-auto pb-4 xl:pb-0">
-          <div className="flex flex-col items-center shrink-0">
-            <span className="text-[10px] uppercase font-bold text-slate-400 mb-2 tracking-widest">Overall Score</span>
-            <div className="relative w-[70px] h-[70px]">
-              <svg className="w-full h-full -rotate-90">
-                <circle cx="35" cy="35" r="30" fill="none" stroke="#F1F5F9" strokeWidth="6" />
-                <circle
-                  cx="35"
-                  cy="35"
-                  r="30"
-                  fill="none"
-                  stroke={getScoreColor(interaction.overallScore)}
-                  strokeWidth="6"
-                  strokeLinecap="round"
-                  strokeDasharray={`${(interaction.overallScore / 100) * 188.5} 188.5`}
-                />
-              </svg>
-              <div className="absolute inset-0 flex items-center justify-center">
-                <span className="text-[18px] font-extrabold" style={{ color: getScoreColor(interaction.overallScore) }}>
-                  {interaction.overallScore}
-                </span>
-              </div>
+      <div className="overflow-hidden rounded-[28px] border border-border bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.18),transparent_30%),linear-gradient(135deg,rgba(255,255,255,0.98),rgba(241,245,249,0.98))] p-8 shadow-sm dark:border-slate-700 dark:bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.18),transparent_30%),linear-gradient(135deg,#0f172a,#111827)]">
+        <div className="flex flex-col gap-8 xl:flex-row xl:items-start xl:justify-between">
+          <div className="max-w-3xl">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-primary/15 bg-primary/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.22em] text-primary">
+              Session review
+            </div>
+            <h2 className="mb-2 text-[30px] font-extrabold tracking-tight text-slate-900 dark:text-slate-100">
+              {interaction.agentName}
+            </h2>
+            <div className="flex flex-wrap items-center gap-3 text-[13px] font-medium text-slate-500 dark:text-slate-300">
+              <span>{interaction.date}</span>
+              <span className="h-1 w-1 rounded-full bg-slate-300" />
+              <span>{interaction.time}</span>
+              <span className="h-1 w-1 rounded-full bg-slate-300" />
+              <span>{interaction.duration}</span>
+              <span className="h-1 w-1 rounded-full bg-slate-300" />
+              <span className="uppercase">{interaction.language}</span>
+            </div>
+            <p className="mt-4 max-w-2xl text-[14px] leading-6 text-slate-600 dark:text-slate-300">
+              {sessionNarrative}
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              {reviewSignals.map((signal) => (
+                <div key={signal.label} className="rounded-2xl border border-slate-200/80 bg-white/75 px-4 py-3 shadow-sm dark:border-slate-700 dark:bg-slate-900/70">
+                  <div className="text-[10px] font-bold uppercase tracking-[0.2em] text-slate-400">{signal.label}</div>
+                  <div className="mt-1 text-[22px] font-extrabold text-slate-900 dark:text-slate-100">{signal.value}</div>
+                </div>
+              ))}
             </div>
           </div>
-          
-          <div className="w-px h-16 bg-slate-200 dark:bg-slate-700 hidden sm:block"></div>
 
-          <div className="flex items-center gap-8 xl:gap-12">
-            {[
-              { label: "Empathy", score: interaction.empathyScore, color: "#3B82F6", unit: "%" },
-              { label: "Policy", score: interaction.policyScore, color: "#10B981", unit: "%" },
-              { label: "Resolution", score: interaction.resolutionScore, color: "#8B5CF6", unit: "%" },
-              { label: "Response Time", score: responseTimeText, color: "#334155", unit: "" },
-            ].map((s) => (
-              <div key={s.label} className="text-center flex flex-col items-center">
-                <div className="text-[10px] text-slate-400 mb-2 uppercase font-extrabold tracking-wider whitespace-nowrap">{s.label}</div>
-                <div className="text-[20px] font-extrabold" style={{ color: s.color }}>
-                  {s.score}{s.unit}
+          <div className="flex w-full flex-col gap-4 xl:w-auto">
+            <div className="flex items-center gap-8 overflow-x-auto pb-2 xl:justify-end">
+              <div className="flex shrink-0 flex-col items-center">
+                <span className="mb-2 text-[10px] font-bold uppercase tracking-widest text-slate-400">Overall Score</span>
+                <div className="relative h-[74px] w-[74px]">
+                  <svg className="h-full w-full -rotate-90">
+                    <circle cx="37" cy="37" r="31" fill="none" stroke="#E2E8F0" strokeWidth="6" />
+                    <circle
+                      cx="37"
+                      cy="37"
+                      r="31"
+                      fill="none"
+                      stroke={getScoreColor(interaction.overallScore)}
+                      strokeWidth="6"
+                      strokeLinecap="round"
+                      strokeDasharray={`${(interaction.overallScore / 100) * 194.7} 194.7`}
+                    />
+                  </svg>
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <span className="text-[18px] font-extrabold" style={{ color: getScoreColor(interaction.overallScore) }}>
+                      {interaction.overallScore}
+                    </span>
+                  </div>
                 </div>
               </div>
-            ))}
+
+              <div className="hidden h-16 w-px bg-slate-200 dark:bg-slate-700 sm:block" />
+
+              <div className="flex items-center gap-8 xl:gap-10">
+                {[
+                  { label: "Empathy", score: interaction.empathyScore, color: "#3B82F6", unit: "%" },
+                  { label: "Policy", score: interaction.policyScore, color: "#10B981", unit: "%" },
+                  { label: "Resolution", score: interaction.resolutionScore, color: "#8B5CF6", unit: "%" },
+                  { label: "Response Time", score: responseTimeText, color: "#334155", unit: "" },
+                ].map((s) => (
+                  <div key={s.label} className="flex flex-col items-center text-center">
+                    <div className="mb-2 whitespace-nowrap text-[10px] font-extrabold uppercase tracking-wider text-slate-400">{s.label}</div>
+                    <div className="text-[20px] font-extrabold" style={{ color: s.color }}>
+                      {s.score}{s.unit}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {isProcessing && (
+              <div className="rounded-2xl border border-amber-200/60 bg-amber-50/80 px-4 py-4 dark:border-amber-900/40 dark:bg-amber-950/20">
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <div className="text-[11px] font-bold uppercase tracking-[0.2em] text-amber-700 dark:text-amber-300">Processing state</div>
+                    <div className="mt-1 text-[13px] font-medium text-amber-900 dark:text-amber-100">
+                      Auto-refresh is on while new transcript and evaluation artifacts arrive.
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {processingSteps.map((step) => (
+                      <div
+                        key={step.label}
+                        className={`rounded-full border px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] ${
+                          step.done
+                            ? "border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900/40 dark:bg-emerald-950/30 dark:text-emerald-300"
+                            : "border-amber-300 bg-amber-100 text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300"
+                        }`}
+                      >
+                        {step.label}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </div>
 
-      {/* Main Content Columns */}
-      <div className="flex flex-col xl:flex-row gap-6">
-        {/* Left Column: Player, Transcript & Graph */}
-        <div className="flex flex-col gap-6 w-full xl:w-[60%] 2xl:w-[65%] shrink-0">
+      {/* Main Content */}
+      <div className="space-y-6">
+        {/* Primary Review Surface: Player, Transcript, and Emotion Graph */}
+        <div className="space-y-6">
           
           {/* New Audio Player Layout */}
-          <div className="bg-white dark:bg-slate-900 rounded-[24px] p-6 pr-8 border border-border dark:border-slate-700 shadow-sm flex items-center gap-6">
+          <div className="rounded-[24px] border border-border bg-[linear-gradient(135deg,rgba(255,255,255,0.98),rgba(239,246,255,0.96))] p-6 pr-8 shadow-sm dark:border-slate-700 dark:bg-[linear-gradient(135deg,#0f172a,#172554)]">
             <audio 
               ref={audioRef} 
               src={getAudioUrl(interaction.id)} 
               preload="metadata"
             />
-            <button 
-              onClick={() => {
-                if (audioRef.current) {
-                  isPlaying ? audioRef.current.pause() : audioRef.current.play();
-                }
-              }}
-              className="w-14 h-14 flex shrink-0 items-center justify-center rounded-full bg-[#3B82F6] text-white hover:bg-blue-600 transition-colors shadow-[0_8px_16px_rgba(59,130,246,0.3)]"
-            >
-              {isPlaying ? (
-                <div className="w-4 h-4 flex justify-between">
-                  <div className="w-1.5 bg-white rounded-sm"></div>
-                  <div className="w-1.5 bg-white rounded-sm"></div>
-                </div>
-              ) : (
-                <Play className="w-6 h-6 ml-1.5 fill-current" />
-              )}
-            </button>
-            
-            <div className="flex-1 flex flex-col justify-center pt-2">
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-[12px] font-bold text-slate-500">{formatClock(currentTimeSeconds)}</span>
-                <span className="text-[12px] font-bold text-slate-400">{formatClock(totalDurationSeconds)}</span>
+            <div className="flex items-center gap-6">
+              <button 
+                onClick={() => {
+                  if (audioRef.current) {
+                    isPlaying ? audioRef.current.pause() : audioRef.current.play();
+                  }
+                }}
+                className="flex h-14 w-14 shrink-0 items-center justify-center rounded-full bg-[#3B82F6] text-white shadow-[0_8px_16px_rgba(59,130,246,0.3)] transition-colors hover:bg-blue-600"
+              >
+                {isPlaying ? (
+                  <div className="flex h-4 w-4 justify-between">
+                    <div className="w-1.5 rounded-sm bg-white"></div>
+                    <div className="w-1.5 rounded-sm bg-white"></div>
+                  </div>
+                ) : (
+                  <Play className="ml-1.5 h-6 w-6 fill-current" />
+                )}
+              </button>
+
+              <div className="flex flex-wrap gap-2">
+                <span className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/30 dark:text-blue-200">
+                  Auto-sync transcript
+                </span>
+                <span className="rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-slate-600 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-300">
+                  {utterances.length} utterances
+                </span>
               </div>
-              <div className="group relative w-full h-[6px] rounded-full bg-slate-100 mb-1">
+            </div>
+
+            <div className="mt-5 flex flex-1 flex-col justify-center pt-2">
+              <div className="mb-2 flex items-center justify-between">
+                <span className="text-[12px] font-bold text-slate-500 dark:text-slate-300">{formatClock(currentTimeSeconds)}</span>
+                <span className="text-[12px] font-bold text-slate-400 dark:text-slate-400">{formatClock(totalDurationSeconds)}</span>
+              </div>
+              <div className="group relative mb-1 h-[6px] w-full rounded-full bg-slate-100 dark:bg-slate-800">
                 <input
                   type="range"
                   min={0}
@@ -639,20 +726,24 @@ export function SessionDetail() {
                   step={0.1}
                   value={progressPercent || 0}
                   onChange={(event) => handleProgressChange(Number(event.target.value))}
-                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer z-10"
+                  className="absolute inset-0 z-10 h-full w-full cursor-pointer opacity-0"
                   aria-label="Audio seek"
                 />
-                <div className="absolute left-0 top-0 bottom-0 bg-[#3B82F6] rounded-full pointer-events-none" style={{ width: `${progressPercent}%` }} />
+                <div className="pointer-events-none absolute bottom-0 left-0 top-0 rounded-full bg-[#3B82F6]" style={{ width: `${progressPercent}%` }} />
                 <div 
-                  className="absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 bg-[#3B82F6] rounded-full shadow border-2 border-white pointer-events-none z-0 transition-transform group-hover:scale-125" 
+                  className="pointer-events-none absolute top-1/2 z-0 h-3.5 w-3.5 -translate-y-1/2 rounded-full border-2 border-white bg-[#3B82F6] shadow transition-transform group-hover:scale-125 dark:border-slate-950" 
                   style={{ left: `calc(${progressPercent}% - 6px)` }} 
                 />
+              </div>
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-[12px] text-slate-500 dark:text-slate-300">
+                <span>Click any transcript span or evidence card to jump playback.</span>
+                <span className="font-semibold">{isProcessing ? "Playback available while analysis finishes" : "Playback synced with transcript view"}</span>
               </div>
             </div>
           </div>
 
           <div className="bg-white dark:bg-slate-900 rounded-[24px] border border-border dark:border-slate-700 overflow-hidden shadow-sm flex flex-col">
-            <div className="p-6 pb-4 border-b border-slate-100 flexitems-center gap-3">
+            <div className="flex items-center gap-3 border-b border-slate-100 p-6 pb-4">
               <h3 className="text-[18px] font-extrabold text-slate-800 dark:text-slate-100 flex items-center gap-2">
                 <svg className="w-5 h-5 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                 Session Transcript
@@ -833,9 +924,12 @@ export function SessionDetail() {
           </div>
         </div>
 
-        {/* Right Column: Cards */}
-        <div className="flex-1 space-y-6 min-w-0">
-          
+        {/* Secondary Review Surface: Evidence and Evaluation Cards */}
+        <div className="space-y-6">
+
+          <EvidenceAnchoredExplainabilityPanel explainability={explainability} onJumpTo={handleJumpTo} />
+
+          <div className="grid gap-6 xl:grid-cols-2 items-start">
           {/* Automated Evaluation Card (RAG Compliance + Policy) */}
           <div className="bg-white dark:bg-slate-900 rounded-[24px] border border-border dark:border-slate-700 shadow-sm flex flex-col overflow-hidden">
             <div className="p-6 bg-slate-900 flex items-start justify-between">
@@ -853,10 +947,33 @@ export function SessionDetail() {
             
             <div className="p-6 space-y-8">
               {!ragCompliance?.available ? (
-                <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-4 text-[13px] text-slate-500 dark:text-slate-300 font-medium">
-                  {isProcessing
-                    ? "Processing audio. RAG compliance will appear once transcription completes."
-                    : `RAG compliance analysis unavailable.${ragCompliance?.error ? ` ${ragCompliance.error}` : ""}`}
+                <div className="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-700 dark:bg-slate-800">
+                  {isProcessing ? (
+                    <div className="space-y-4">
+                      <div>
+                        <p className="text-[13px] font-semibold text-slate-700 dark:text-slate-100">
+                          Policy and SOP checks are still being assembled.
+                        </p>
+                        <p className="mt-1 text-[13px] leading-6 text-slate-500 dark:text-slate-300">
+                          Retrieval provenance will appear here once transcription completes and policy chunks are scored.
+                        </p>
+                      </div>
+                      <div className="grid gap-3">
+                        {processingSteps.map((step) => (
+                          <div key={`rag-${step.label}`} className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 dark:border-slate-700 dark:bg-slate-900/70">
+                            <span className="text-[12px] font-bold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-300">{step.label}</span>
+                            <span className={`rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] ${step.done ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-300" : "bg-amber-100 text-amber-700 dark:bg-amber-950/30 dark:text-amber-300"}`}>
+                              {step.done ? "Ready" : "Queued"}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-[13px] font-medium text-slate-500 dark:text-slate-300">
+                      {`RAG compliance analysis unavailable.${ragCompliance?.error ? ` ${ragCompliance.error}` : ""}`}
+                    </p>
+                  )}
                 </div>
               ) : (
                 <>
@@ -944,10 +1061,32 @@ export function SessionDetail() {
               </div>
               <div className="p-6">
                 {!emotionTriggers.available ? (
-                  <div className="rounded-xl border border-destructive/20 bg-destructive/5 p-4 text-[13px] text-destructive font-medium">
-                    {isProcessing
-                      ? "Processing audio. Emotion reasoning will appear once transcription completes."
-                      : `Emotion trigger analysis unavailable.${emotionTriggers.error ? ` ${emotionTriggers.error}` : ""}`}
+                  <div className="rounded-2xl border border-purple-200 bg-purple-50/70 p-5 dark:border-purple-900/40 dark:bg-purple-950/20">
+                    {isProcessing ? (
+                      <div className="space-y-3">
+                        <p className="text-[13px] font-semibold text-purple-800 dark:text-purple-200">
+                          Emotion reasoning is waiting on transcript-aligned cues.
+                        </p>
+                        <p className="text-[13px] leading-6 text-purple-700/80 dark:text-purple-200/80">
+                          Once the call is transcribed, this card will anchor acoustic or transcript mismatches to exact utterance spans.
+                        </p>
+                        <div className="grid gap-2">
+                          {[
+                            "Customer emotion summary",
+                            "Trigger reasoning",
+                            "Counterfactual coaching",
+                          ].map((item) => (
+                            <div key={item} className="rounded-xl border border-purple-200/80 bg-white/80 px-4 py-3 text-[12px] font-medium text-purple-700 dark:border-purple-900/40 dark:bg-slate-900/70 dark:text-purple-200">
+                              {item}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-[13px] font-medium text-destructive">
+                        {`Emotion trigger analysis unavailable.${emotionTriggers.error ? ` ${emotionTriggers.error}` : ""}`}
+                      </p>
+                    )}
                   </div>
                 ) : emotionTriggers.emotionShift && (
                   <div className="space-y-6">
@@ -965,7 +1104,9 @@ export function SessionDetail() {
                     {/* Dissonance Detection */}
                     <div className="flex items-center gap-3">
                       <span className={`px-3 py-1.5 rounded-full text-[11px] font-extrabold uppercase tracking-wider border ${emotionTriggers.emotionShift.isDissonanceDetected ? "bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-800" : "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300 border-emerald-200 dark:border-emerald-800"}`}>
-                        {emotionTriggers.emotionShift.isDissonanceDetected ? `⚡ ${emotionTriggers.emotionShift.dissonanceType || "Dissonance"}` : "✓ No Dissonance"}
+                        {emotionTriggers.emotionShift.isDissonanceDetected
+                          ? `Alert: ${emotionTriggers.emotionShift.dissonanceType || "Dissonance"}`
+                          : "No Dissonance"}
                       </span>
                       {emotionTriggers.emotionShift.insufficientEvidence && (
                         <span className="px-2.5 py-1 rounded-full text-[10px] font-bold bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-slate-700">
@@ -1020,6 +1161,8 @@ export function SessionDetail() {
               </div>
             </div>
           )}
+
+          </div>
 
         </div>
       </div>

--- a/frontend/src/app/components/manager/SessionInspector.tsx
+++ b/frontend/src/app/components/manager/SessionInspector.tsx
@@ -1,6 +1,16 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router";
-import { Search, ChevronDown, Loader2, AlertTriangle } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  Clock3,
+  Loader2,
+  RefreshCw,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  Upload,
+} from "lucide-react";
 import {
   createInteraction,
   getAgents,
@@ -9,6 +19,29 @@ import {
   type AgentSummary,
   type InteractionSummary,
 } from "../../services/api";
+
+type SortField = "score" | "date" | "duration";
+
+function parseDuration(duration: string): number {
+  const [minutes, seconds] = duration.split(":").map(Number);
+  return ((minutes || 0) * 60) + (seconds || 0);
+}
+
+function getStatusMeta(status: string, resolved: boolean) {
+  const normalized = (status || "").toLowerCase();
+  if (normalized === "failed") return { label: "Failed", tone: "border-red-500/20 bg-red-500/10 text-red-200" };
+  if (normalized === "pending" || normalized === "processing") {
+    return { label: "Processing", tone: "border-amber-400/20 bg-amber-400/10 text-amber-100" };
+  }
+  if (resolved) return { label: "Resolved", tone: "border-emerald-400/20 bg-emerald-400/10 text-emerald-100" };
+  return { label: "Needs review", tone: "border-red-500/20 bg-red-500/10 text-red-200" };
+}
+
+function getScoreMeta(score: number) {
+  if (score >= 85) return { text: "text-emerald-300", bar: "bg-emerald-400", card: "from-emerald-500/20 to-transparent" };
+  if (score >= 75) return { text: "text-blue-300", bar: "bg-blue-400", card: "from-blue-500/20 to-transparent" };
+  return { text: "text-red-300", bar: "bg-red-400", card: "from-red-500/20 to-transparent" };
+}
 
 export function SessionInspector() {
   const navigate = useNavigate();
@@ -20,27 +53,29 @@ export function SessionInspector() {
   const [agents, setAgents] = useState<AgentSummary[]>([]);
   const [showUploadModal, setShowUploadModal] = useState(false);
   const [selectedAudioFile, setSelectedAudioFile] = useState<File | null>(null);
-  const [selectedUploadAgentId, setSelectedUploadAgentId] = useState<string>("");
+  const [selectedUploadAgentId, setSelectedUploadAgentId] = useState("");
   const [uploading, setUploading] = useState(false);
-
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedAgent, setSelectedAgent] = useState("All Agents");
-  const [sortField, setSortField] = useState<"score" | "date" | "duration">("score");
+  const [sortField, setSortField] = useState<SortField>("score");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [currentPage, setCurrentPage] = useState(1);
   const itemsPerPage = 10;
 
-  const loadInteractions = () => {
+  const loadInteractions = async () => {
     setLoading(true);
     setLoadError(null);
-    getInteractions()
-      .then(setInteractions)
-      .catch((err) => setLoadError(err.message))
-      .finally(() => setLoading(false));
+    try {
+      setInteractions(await getInteractions());
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : "Failed to load interactions");
+    } finally {
+      setLoading(false);
+    }
   };
 
   useEffect(() => {
-    loadInteractions();
+    void loadInteractions();
     getAgents().then(setAgents).catch(() => setAgents([]));
   }, []);
 
@@ -94,361 +129,330 @@ export function SessionInspector() {
     }
   };
 
-  const handleSort = (field: "score" | "date" | "duration") => {
-    if (sortField === field) {
-      setSortOrder(sortOrder === "asc" ? "desc" : "asc");
-    } else {
-      setSortField(field);
-      setSortOrder("desc");
-    }
-    setCurrentPage(1);
-  };
+  const uniqueAgents = useMemo(
+    () => Array.from(new Set(interactions.map((interaction) => interaction.agentName))).sort(),
+    [interactions],
+  );
 
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center h-96">
-        <Loader2 className="w-8 h-8 text-primary animate-spin" />
-        <span className="ml-3 text-muted-foreground text-sm">Loading interactions...</span>
-      </div>
-    );
-  }
+  const filteredInteractions = useMemo(() => {
+    return interactions.filter((interaction) => {
+      const searchLower = searchQuery.toLowerCase();
+      const matchesSearch =
+        interaction.agentName.toLowerCase().includes(searchLower) ||
+        interaction.id.toLowerCase().includes(searchLower) ||
+        interaction.date.toLowerCase().includes(searchLower);
+      const matchesAgent = selectedAgent === "All Agents" || interaction.agentName === selectedAgent;
+      return matchesSearch && matchesAgent;
+    });
+  }, [interactions, searchQuery, selectedAgent]);
 
-  if (loadError) {
-    return (
-      <div className="flex items-center justify-center h-96">
-        <div className="text-center">
-          <AlertTriangle className="w-10 h-10 text-destructive mx-auto mb-3" />
-          <p className="text-foreground text-sm">Failed to load interactions</p>
-          <p className="text-muted-foreground/80 text-xs mt-1">{loadError}</p>
-        </div>
-      </div>
-    );
-  }
-
-  const uniqueAgents = Array.from(new Set(interactions.map(i => i.agentName))).sort();
-
-  const filteredInteractions = interactions.filter((interaction) => {
-    const searchLower = searchQuery.toLowerCase();
-    const matchesSearch = interaction.agentName.toLowerCase().includes(searchLower) ||
-                          interaction.id.toLowerCase().includes(searchLower) ||
-                          interaction.date.toLowerCase().includes(searchLower);
-    const matchesAgent = selectedAgent === "All Agents" || interaction.agentName === selectedAgent;
-    return matchesSearch && matchesAgent;
-  });
-
-  const sortedInteractions = [...filteredInteractions].sort((a, b) => {
-    let comparison = 0;
-    if (sortField === "score") {
-      comparison = a.overallScore - b.overallScore;
-    } else if (sortField === "date") {
-      const dateA = new Date(`${a.date}T${a.time}`).getTime();
-      const dateB = new Date(`${b.date}T${b.time}`).getTime();
-      comparison = dateA - dateB;
-    } else if (sortField === "duration") {
-      const [mA, sA] = a.duration.split(":").map(Number);
-      const [mB, sB] = b.duration.split(":").map(Number);
-      const durA = (mA || 0) * 60 + (sA || 0);
-      const durB = (mB || 0) * 60 + (sB || 0);
-      comparison = durA - durB;
-    }
-    return sortOrder === "asc" ? comparison : -comparison;
-  });
+  const sortedInteractions = useMemo(() => {
+    return [...filteredInteractions].sort((a, b) => {
+      let comparison = 0;
+      if (sortField === "score") comparison = a.overallScore - b.overallScore;
+      if (sortField === "date") comparison = new Date(`${a.date}T${a.time}`).getTime() - new Date(`${b.date}T${b.time}`).getTime();
+      if (sortField === "duration") comparison = parseDuration(a.duration) - parseDuration(b.duration);
+      return sortOrder === "asc" ? comparison : -comparison;
+    });
+  }, [filteredInteractions, sortField, sortOrder]);
 
   const totalItems = sortedInteractions.length;
   const totalPages = Math.max(1, Math.ceil(totalItems / itemsPerPage));
   const startIndex = (currentPage - 1) * itemsPerPage;
   const paginatedInteractions = sortedInteractions.slice(startIndex, startIndex + itemsPerPage);
 
+  const summary = useMemo(() => {
+    const processing = interactions.filter((item) => ["pending", "processing"].includes((item.status || "").toLowerCase())).length;
+    const flagged = interactions.filter((item) => item.hasViolation || !item.resolved || (item.status || "").toLowerCase() === "failed").length;
+    const avgScore = interactions.length
+      ? Math.round(interactions.reduce((total, item) => total + item.overallScore, 0) / interactions.length)
+      : 0;
+    const completed = interactions.filter((item) => (item.status || "").toLowerCase() === "completed").length;
+    return {
+      total: interactions.length,
+      processing,
+      flagged,
+      avgScore,
+      completionRate: interactions.length ? Math.round((completed / interactions.length) * 100) : 0,
+    };
+  }, [interactions]);
+
+  if (loading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <span className="ml-3 text-sm text-muted-foreground">Loading interactions...</span>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <div className="text-center">
+          <AlertTriangle className="mx-auto mb-3 h-10 w-10 text-destructive" />
+          <p className="text-sm text-foreground">Failed to load interactions</p>
+          <p className="mt-1 text-xs text-muted-foreground/80">{loadError}</p>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4 md:p-8 max-w-[1600px] mx-auto">
-      {/* Header */}
-      <div className="mb-8">
-        <div className="flex items-start justify-between mb-4">
-          <div>
-            <h2 className="text-[26px] font-extrabold text-foreground tracking-tight">Session Inspector</h2>
-            <p className="text-[13px] text-muted-foreground mt-1">
-              {totalItems} interaction{totalItems !== 1 ? "s" : ""} found
-            </p>
+    <div className="mx-auto max-w-[1600px] p-4 md:p-8">
+      <div className="mb-8 space-y-6">
+        <div className="overflow-hidden rounded-[28px] border border-slate-800 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.24),transparent_32%),linear-gradient(135deg,#0f172a_0%,#111827_55%,#0b1220_100%)] px-6 py-6 shadow-[0_24px_60px_rgba(2,6,23,0.34)] md:px-8">
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div className="max-w-3xl">
+                <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-blue-400/20 bg-blue-400/10 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.22em] text-blue-100">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  Manager overview
+                </div>
+                <h2 className="text-[28px] font-extrabold tracking-tight text-white md:text-[34px]">Session Inspector</h2>
+                <p className="mt-2 max-w-2xl text-[14px] leading-6 text-slate-300">
+                  Review live processing, surface risky calls, and jump into explainable evidence faster.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-3">
+                {summary.processing > 0 && (
+                  <div className="inline-flex items-center gap-2 rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-2 text-[12px] font-semibold text-amber-100">
+                    <Clock3 className="h-4 w-4" />
+                    {summary.processing} active pipeline run{summary.processing !== 1 ? "s" : ""}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setShowUploadModal(true)}
+                  className="inline-flex h-11 items-center gap-2 rounded-2xl bg-primary px-5 text-[13px] font-bold text-primary-foreground shadow-[0_8px_24px_rgba(59,130,246,0.34)] transition-all hover:-translate-y-0.5 hover:bg-primary/90"
+                >
+                  <Upload className="h-4 w-4" />
+                  Upload Audio
+                </button>
+              </div>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {[
+                { label: "Visible sessions", value: `${summary.total}`, helper: `${summary.completionRate}% completed` },
+                { label: "Average score", value: `${summary.avgScore}%`, helper: "Across loaded calls" },
+                { label: "Flagged sessions", value: `${summary.flagged}`, helper: "Violation, unresolved, or failed" },
+                { label: "Filtered results", value: `${totalItems}`, helper: searchQuery || selectedAgent !== "All Agents" ? "Filters applied" : "No filters active" },
+              ].map((item) => (
+                <div key={item.label} className="rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur-sm">
+                  <div className="text-[11px] font-bold uppercase tracking-[0.22em] text-slate-400">{item.label}</div>
+                  <div className="mt-3 text-[28px] font-extrabold text-white">{item.value}</div>
+                  <div className="mt-1 text-[12px] text-slate-400">{item.helper}</div>
+                </div>
+              ))}
+            </div>
           </div>
-          <button
-            type="button"
-            onClick={() => setShowUploadModal(true)}
-            className="h-11 px-6 rounded-2xl bg-primary text-primary-foreground text-[13px] font-bold hover:bg-primary/90 transition-all shadow-[0_4px_12px_rgba(59,130,246,0.3)] hover:shadow-[0_6px_20px_rgba(59,130,246,0.4)]"
-          >
-            + Upload Audio
-          </button>
         </div>
 
-        {/* Filters Row */}
-        <div className="flex items-center gap-3 flex-wrap">
-          <div className="relative flex-1 min-w-[180px] max-w-[280px]">
-            <Search className="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-            <input
-              type="text"
-              placeholder="Search agent, date, ID…"
-              value={searchQuery}
-              onChange={(e) => {
-                setSearchQuery(e.target.value);
-                setCurrentPage(1);
-              }}
-              className="w-full h-10 pl-10 pr-3 bg-card border border-border rounded-xl text-[13px] focus:outline-none focus:ring-2 focus:ring-primary/30 transition-all"
-            />
-          </div>
+        <div className="rounded-[24px] border border-slate-800/80 bg-slate-950/60 p-4 shadow-[0_16px_36px_rgba(2,6,23,0.2)]">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div className="flex flex-1 flex-col gap-3 md:flex-row md:flex-wrap md:items-center">
+              <div className="relative min-w-[220px] flex-1 md:max-w-[340px]">
+                <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+                <input
+                  type="text"
+                  placeholder="Search agent, date, ID..."
+                  value={searchQuery}
+                  onChange={(event) => {
+                    setSearchQuery(event.target.value);
+                    setCurrentPage(1);
+                  }}
+                  className="h-11 w-full rounded-xl border border-slate-800 bg-slate-900/80 pl-10 pr-3 text-[13px] text-slate-100 outline-none transition-all placeholder:text-slate-500 focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+                />
+              </div>
 
-          <div className="relative">
-            <select
-              value={selectedAgent}
-              onChange={(e) => {
-                setSelectedAgent(e.target.value);
-                setCurrentPage(1);
-              }}
-              className="appearance-none h-10 pl-4 pr-10 bg-card border border-border rounded-xl text-[13px] hover:bg-muted/30 transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 cursor-pointer"
+              <div className="relative">
+                <select
+                  value={selectedAgent}
+                  onChange={(event) => {
+                    setSelectedAgent(event.target.value);
+                    setCurrentPage(1);
+                  }}
+                  className="h-11 appearance-none rounded-xl border border-slate-800 bg-slate-900/80 pl-4 pr-10 text-[13px] text-slate-100 outline-none transition-colors hover:border-slate-700 focus:border-primary/50 focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="All Agents">All Agents</option>
+                  {uniqueAgents.map((agent) => (
+                    <option key={agent} value={agent}>
+                      {agent}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+              </div>
+
+              <div className="flex items-center overflow-hidden rounded-xl border border-slate-800 bg-slate-900/80">
+                {(["score", "date", "duration"] as const).map((field) => (
+                  <button
+                    key={field}
+                    type="button"
+                    onClick={() => {
+                      if (sortField === field) {
+                        setSortOrder(sortOrder === "asc" ? "desc" : "asc");
+                      } else {
+                        setSortField(field);
+                        setSortOrder("desc");
+                      }
+                      setCurrentPage(1);
+                    }}
+                    className={`h-11 px-4 text-[11px] font-bold uppercase tracking-[0.2em] transition-all ${
+                      sortField === field ? "bg-primary text-primary-foreground" : "text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+                    }`}
+                  >
+                    {field}
+                    {sortField === field ? ` ${sortOrder === "desc" ? "v" : "^"}` : ""}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => void loadInteractions()}
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-slate-800 bg-slate-900/80 px-4 text-[12px] font-bold text-slate-200 transition-colors hover:border-slate-700 hover:bg-slate-800"
             >
-              <option value="All Agents">All Agents</option>
-              {uniqueAgents.map(agent => (
-                <option key={agent} value={agent}>{agent}</option>
-              ))}
-            </select>
-            <ChevronDown className="w-4 h-4 absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-muted-foreground" />
-          </div>
-
-          <div className="flex items-center border border-border rounded-xl overflow-hidden bg-card shadow-sm">
-            {(["score", "date", "duration"] as const).map((field) => (
-              <button
-                key={field}
-                onClick={() => handleSort(field)}
-                className={`px-4 h-10 text-[11px] font-bold uppercase tracking-wider transition-all ${sortField === field ? "bg-primary text-primary-foreground shadow-inner" : "text-muted-foreground hover:bg-muted/40"}`}
-              >
-                {field} {sortField === field ? (sortOrder === "desc" ? "↓" : "↑") : ""}
-              </button>
-            ))}
+              <RefreshCw className="h-4 w-4" />
+              Refresh
+            </button>
           </div>
         </div>
       </div>
 
-      {actionError && (
-        <div className="mb-4 rounded-[10px] border border-destructive/30 bg-destructive/5 px-4 py-3 text-[12px] font-medium text-destructive">
-          {actionError}
-        </div>
-      )}
+      {actionError && <div className="mb-4 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-[12px] font-medium text-destructive">{actionError}</div>}
 
       {showUploadModal && (
-        <div className="fixed inset-0 z-50 bg-black/40 backdrop-blur-[1px] flex items-center justify-center p-4">
-          <div className="w-full max-w-2xl rounded-2xl border border-border bg-card p-6 shadow-2xl">
-            <h3 className="text-[18px] font-bold text-foreground mb-2">Upload Real Audio Interaction</h3>
-            <p className="text-[13px] text-muted-foreground mb-6">Select an agent and upload one call at a time to run the full pipeline.</p>
-
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-[2px]">
+          <div className="w-full max-w-2xl rounded-[26px] border border-slate-800 bg-slate-950 p-6 shadow-[0_30px_80px_rgba(0,0,0,0.45)]">
+            <h3 className="text-[18px] font-bold text-slate-50">Upload Real Audio Interaction</h3>
+            <p className="mb-6 mt-2 text-[13px] text-slate-400">Select an agent and upload one call at a time to run the full evaluation pipeline.</p>
             <div className="space-y-6">
-              {/* Agent Selection */}
               <div>
-                <label className="block text-[12px] font-semibold text-foreground mb-3">Select Agent</label>
+                <label className="mb-3 block text-[12px] font-semibold text-slate-200">Select Agent</label>
                 {agents.length === 0 ? (
-                  <div className="p-4 bg-muted/20 rounded-[10px] text-[13px] text-muted-foreground text-center">
-                    No agents available. Create agents first in the organization settings.
-                  </div>
+                  <div className="rounded-xl border border-slate-800 bg-slate-900/70 p-4 text-center text-[13px] text-slate-400">No agents available. Create agents first in the organization settings.</div>
                 ) : (
-                  <div className="grid grid-cols-2 gap-3">
-                    <button
-                      type="button"
-                      onClick={() => setSelectedUploadAgentId("")}
-                      className={`p-3 rounded-[12px] border-2 transition-all text-left ${
-                        selectedUploadAgentId === ""
-                          ? "border-primary bg-primary/5"
-                          : "border-border bg-muted/20 hover:border-primary/50"
-                      }`}
-                    >
-                      <div className="text-[13px] font-semibold text-foreground">Auto-Select</div>
-                      <div className="text-[11px] text-muted-foreground mt-1">Use first active agent</div>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <button type="button" onClick={() => setSelectedUploadAgentId("")} className={`rounded-2xl border p-4 text-left transition-all ${selectedUploadAgentId === "" ? "border-primary bg-primary/10" : "border-slate-800 bg-slate-900/60 hover:border-primary/40"}`}>
+                      <div className="text-[13px] font-semibold text-slate-100">Auto-Select</div>
+                      <div className="mt-1 text-[11px] text-slate-400">Use the first active agent</div>
                     </button>
                     {agents.map((agent) => (
-                      <button
-                        key={agent.id}
-                        type="button"
-                        onClick={() => setSelectedUploadAgentId(agent.id)}
-                        className={`p-3 rounded-[12px] border-2 transition-all text-left ${
-                          selectedUploadAgentId === agent.id
-                            ? "border-primary bg-primary/5"
-                            : "border-border bg-muted/20 hover:border-primary/50"
-                        }`}
-                      >
-                        <div className="text-[13px] font-semibold text-foreground">{agent.name}</div>
-                        <div className="text-[11px] text-muted-foreground mt-1">{agent.role || "Agent"}</div>
+                      <button key={agent.id} type="button" onClick={() => setSelectedUploadAgentId(agent.id)} className={`rounded-2xl border p-4 text-left transition-all ${selectedUploadAgentId === agent.id ? "border-primary bg-primary/10" : "border-slate-800 bg-slate-900/60 hover:border-primary/40"}`}>
+                        <div className="text-[13px] font-semibold text-slate-100">{agent.name}</div>
+                        <div className="mt-1 text-[11px] text-slate-400">{agent.role || "Agent"}</div>
                       </button>
                     ))}
                   </div>
                 )}
               </div>
-
-              {/* Audio File */}
               <div>
-                <label className="block text-[12px] font-semibold text-foreground mb-2">Audio File (.wav or .mp3)</label>
-                <input
-                  type="file"
-                  accept=".wav,.mp3,audio/wav,audio/mpeg"
-                  onChange={(e) => setSelectedAudioFile(e.target.files?.[0] ?? null)}
-                  className="w-full text-[13px] file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-[13px] file:font-semibold file:bg-primary file:text-primary-foreground hover:file:bg-primary/90"
-                />
-                {selectedAudioFile && (
-                  <p className="text-[11px] text-muted-foreground mt-2">
-                    ✓ Selected: {selectedAudioFile.name}
-                  </p>
-                )}
+                <label className="mb-2 block text-[12px] font-semibold text-slate-200">Audio File (.wav or .mp3)</label>
+                <input type="file" accept=".wav,.mp3,audio/wav,audio/mpeg" onChange={(event) => setSelectedAudioFile(event.target.files?.[0] ?? null)} className="w-full text-[13px] text-slate-200 file:mr-4 file:rounded-xl file:border-0 file:bg-primary file:px-4 file:py-2.5 file:text-[13px] file:font-semibold file:text-primary-foreground hover:file:bg-primary/90" />
+                {selectedAudioFile && <p className="mt-2 text-[11px] text-slate-400">Selected: {selectedAudioFile.name}</p>}
               </div>
             </div>
-
             <div className="mt-6 flex items-center justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => {
-                  if (!uploading) {
-                    setShowUploadModal(false);
-                    setSelectedAudioFile(null);
-                    setSelectedUploadAgentId("");
-                  }
-                }}
-                className="h-10 px-4 rounded-[10px] border border-border text-[13px] font-semibold hover:bg-muted transition-colors"
-                disabled={uploading}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleUploadInteraction()}
-                className="h-10 px-4 rounded-[10px] bg-primary text-primary-foreground text-[13px] font-semibold disabled:opacity-60 hover:bg-primary/90 transition-colors"
-                disabled={uploading || !selectedAudioFile}
-              >
-                {uploading ? "Uploading..." : "Upload & Process"}
-              </button>
+              <button type="button" onClick={() => { if (!uploading) { setShowUploadModal(false); setSelectedAudioFile(null); setSelectedUploadAgentId(""); } }} className="h-10 rounded-xl border border-slate-800 px-4 text-[13px] font-semibold text-slate-200 transition-colors hover:bg-slate-900" disabled={uploading}>Cancel</button>
+              <button type="button" onClick={() => void handleUploadInteraction()} className="h-10 rounded-xl bg-primary px-4 text-[13px] font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60" disabled={uploading || !selectedAudioFile}>{uploading ? "Uploading..." : "Upload and Process"}</button>
             </div>
           </div>
         </div>
       )}
 
-      {/* Table Card */}
-      <div className="bg-card rounded-2xl border border-border overflow-hidden shadow-sm">
-        <table className="w-full border-collapse">
-          <thead>
-            <tr className="bg-muted/10 border-b border-border">
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Agent</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Date & Time</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Duration</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Score</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Empathy</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Policy</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Resolution</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Status</th>
-              <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-widest text-muted-foreground">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-border/50">
-            {paginatedInteractions.length === 0 ? (
-              <tr>
-                <td colSpan={9} className="px-6 py-16 text-center text-muted-foreground">
-                  <div className="flex flex-col items-center justify-center">
-                    <Search className="w-10 h-10 opacity-20 mb-3" />
-                    <p className="text-[14px] font-medium text-foreground">No interactions found</p>
-                    <p className="text-[12px] opacity-70 mt-1">Try adjusting your filters or search query.</p>
-                  </div>
-                </td>
+      <div className="overflow-hidden rounded-[28px] border border-slate-800 bg-[linear-gradient(180deg,rgba(15,23,42,0.98),rgba(10,15,27,0.98))] shadow-[0_24px_60px_rgba(2,6,23,0.25)]">
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse">
+            <thead>
+              <tr className="border-b border-slate-800 bg-white/[0.03]">
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Agent</th>
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Date and time</th>
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Duration</th>
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Score</th>
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Signals</th>
+                <th className="px-6 py-4 text-left text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Status</th>
+                <th className="px-6 py-4 text-right text-[10px] font-extrabold uppercase tracking-[0.22em] text-slate-500">Actions</th>
               </tr>
-            ) : paginatedInteractions.map((row) => {
-              const scoreColor = row.overallScore >= 85 ? "var(--success)" : row.overallScore >= 75 ? "var(--primary)" : "var(--destructive)";
-              const rowStatus = (row.status || "").toLowerCase();
-              const isRowProcessing = ["pending", "processing"].includes(rowStatus);
-              const statusBadge = rowStatus === "failed"
-                ? { className: "bg-destructive/5 text-destructive border-destructive/20", label: "⚠ Failed" }
-                : isRowProcessing
-                  ? { className: "bg-amber-50 text-amber-700 border-amber-200", label: "⟳ Processing" }
-                  : row.resolved
-                    ? { className: "bg-success/5 text-success border-success/20", label: "✓ Resolved" }
-                    : { className: "bg-destructive/5 text-destructive border-destructive/20", label: "✗ Unresolved" };
-              return (
-              <tr key={row.id} className="group hover:bg-primary/[0.03] transition-colors">
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <div className="flex items-center gap-2.5">
-                    <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-[11px] font-extrabold text-primary shrink-0">
-                      {row.agentName.charAt(0).toUpperCase()}
-                    </div>
-                    <div>
-                      <span className="text-[13px] font-bold text-foreground block">{row.agentName}</span>
-                      {row.hasViolation && (
-                        <span className="px-1.5 py-0.5 bg-destructive/10 text-destructive rounded text-[9px] font-bold">
-                          ⚠ Violation
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-[12px] text-muted-foreground font-medium">
-                  <div>{row.date}</div>
-                  <div className="text-[11px] opacity-70">{row.time}</div>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-[13px] font-bold text-foreground/70">
-                  {row.duration}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <div
-                    className="text-[20px] font-extrabold tabular-nums"
-                    style={{ color: scoreColor }}
-                  >
-                    {row.overallScore}%
-                  </div>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-[13px] font-bold text-foreground">{row.empathyScore}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-[13px] font-bold text-foreground">{row.policyScore}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-[13px] font-bold text-foreground">{row.resolutionScore}</td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <span className={`px-2.5 py-1 rounded-full text-[11px] font-bold border ${statusBadge.className}`}>
-                    {statusBadge.label}
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-right">
-                  <div className="flex items-center justify-end gap-3">
-                    <button
-                      type="button"
-                      disabled={reprocessingIds.has(row.id) || isRowProcessing}
-                      onClick={() => void handleReprocess(row.id)}
-                      className="text-[12px] font-bold text-foreground/60 hover:text-foreground disabled:opacity-40 transition-colors"
-                    >
-                      {isRowProcessing ? "Processing..." : reprocessingIds.has(row.id) ? "Reprocessing..." : "Reprocess"}
-                    </button>
-                    <Link
-                      to={`/manager/inspector/${row.id}`}
-                      className="px-3 py-1.5 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 font-bold text-[12px] transition-all"
-                    >
-                      Inspect →
-                    </Link>
-                  </div>
-                </td>
-              </tr>
-            );
-            })}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-slate-800/80">
+              {paginatedInteractions.length === 0 ? null : paginatedInteractions.map((row) => {
+                const status = getStatusMeta(row.status, row.resolved);
+                const score = getScoreMeta(row.overallScore);
+                const isRowProcessing = ["pending", "processing"].includes((row.status || "").toLowerCase());
+                const isReprocessing = reprocessingIds.has(row.id);
+                return (
+                  <tr key={row.id} className="group transition-colors hover:bg-white/[0.02]">
+                    <td className="px-6 py-5 align-top">
+                      <div className="flex items-start gap-3">
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-blue-400/20 bg-blue-400/10 text-[13px] font-extrabold text-blue-200">{row.agentName.charAt(0).toUpperCase()}</div>
+                        <div className="space-y-1">
+                          <div className="text-[14px] font-bold text-slate-100">{row.agentName}</div>
+                          <div className="text-[12px] text-slate-500">{row.id}</div>
+                          <div className="flex flex-wrap gap-2 pt-1">
+                            {row.hasViolation && <span className="inline-flex items-center gap-1 rounded-full border border-red-500/20 bg-red-500/10 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-red-200"><ShieldAlert className="h-3 w-3" />Violation</span>}
+                            {row.language && <span className="rounded-full border border-slate-700 bg-slate-900/80 px-2 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-slate-400">{row.language}</span>}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-5 align-top">
+                      <div className="space-y-1">
+                        <div className="text-[13px] font-semibold text-slate-200">{row.date}</div>
+                        <div className="text-[12px] text-slate-500">{row.time}</div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-5 align-top"><div className="rounded-2xl border border-slate-800 bg-slate-900/60 px-3 py-3"><div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500">Call length</div><div className="mt-1 text-[18px] font-extrabold text-slate-100">{row.duration}</div></div></td>
+                    <td className="px-6 py-5 align-top">
+                      <div className={`rounded-2xl border border-white/10 bg-gradient-to-br ${score.card} px-4 py-3`}>
+                        <div className={`text-[24px] font-extrabold tabular-nums ${score.text}`}>{row.overallScore}%</div>
+                        <div className="text-[11px] font-medium text-slate-400">Overall evaluation</div>
+                        <div className="mt-3 h-1.5 rounded-full bg-slate-900/80"><div className={`h-1.5 rounded-full ${score.bar}`} style={{ width: `${Math.max(6, Math.min(100, row.overallScore))}%` }} /></div>
+                      </div>
+                    </td>
+                    <td className="px-6 py-5 align-top">
+                      <div className="grid min-w-[230px] grid-cols-3 gap-2">
+                        {[{ label: "Empathy", value: row.empathyScore }, { label: "Policy", value: row.policyScore }, { label: "Resolution", value: row.resolutionScore }].map((metric) => (
+                          <div key={metric.label} className="rounded-2xl border border-slate-800 bg-slate-900/60 px-3 py-3">
+                            <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-slate-500">{metric.label}</div>
+                            <div className="mt-1 text-[18px] font-extrabold text-slate-100">{metric.value}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-6 py-5 align-top"><span className={`inline-flex items-center rounded-full border px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] ${status.tone}`}>{status.label}</span></td>
+                    <td className="px-6 py-5 text-right align-top">
+                      <div className="flex flex-col items-end gap-2">
+                        <button type="button" disabled={isReprocessing || isRowProcessing} onClick={() => void handleReprocess(row.id)} className="inline-flex h-9 items-center justify-center rounded-xl border border-slate-800 bg-slate-900/80 px-4 text-[12px] font-bold text-slate-200 transition-colors hover:border-slate-700 hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40">{isRowProcessing ? "Processing..." : isReprocessing ? "Reprocessing..." : "Reprocess"}</button>
+                        <Link to={`/manager/inspector/${row.id}`} className="inline-flex h-9 items-center justify-center rounded-xl bg-primary px-4 text-[12px] font-bold text-primary-foreground transition-all hover:-translate-y-0.5 hover:bg-primary/90">Inspect</Link>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
 
-        {/* Pagination */}
-        <div className="px-6 py-4 bg-muted/5 border-t border-border flex items-center justify-between">
-          <div className="text-[13px] text-muted-foreground font-medium">
-            Showing {startIndex + 1}–{Math.min(startIndex + itemsPerPage, totalItems)} of {totalItems}
+        {paginatedInteractions.length === 0 && (
+          <div className="px-6 py-20">
+            <div className="mx-auto flex max-w-md flex-col items-center text-center">
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/80"><Search className="h-6 w-6 text-slate-500" /></div>
+              <p className="mt-5 text-[16px] font-bold text-slate-100">No interactions found</p>
+              <p className="mt-2 text-[13px] leading-6 text-slate-400">Try adjusting your filters, clearing the search, or upload a fresh call to populate the queue.</p>
+              <button type="button" onClick={() => setShowUploadModal(true)} className="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2.5 text-[13px] font-bold text-primary-foreground transition-colors hover:bg-primary/90"><Upload className="h-4 w-4" />Upload Audio</button>
+            </div>
           </div>
+        )}
+
+        <div className="flex flex-col gap-3 border-t border-slate-800 bg-white/[0.03] px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <div className="text-[13px] font-medium text-slate-400">Showing {totalItems === 0 ? 0 : startIndex + 1} to {Math.min(startIndex + itemsPerPage, totalItems)} of {totalItems}</div>
           <div className="flex items-center gap-2">
-            <button
-              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-              disabled={currentPage === 1}
-              className="h-9 px-4 rounded-xl border border-border bg-background text-[13px] font-bold text-foreground hover:bg-muted disabled:opacity-40 transition-all"
-            >
-              ← Prev
-            </button>
-            <span className="px-3 text-[12px] font-bold text-muted-foreground tabular-nums">
-              {currentPage} / {totalPages}
-            </span>
-            <button
-              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-              disabled={currentPage === totalPages || totalItems === 0}
-              className="h-9 px-4 rounded-xl border border-border bg-background text-[13px] font-bold text-foreground hover:bg-muted disabled:opacity-40 transition-all"
-            >
-              Next →
-            </button>
+            <button type="button" onClick={() => setCurrentPage((page) => Math.max(1, page - 1))} disabled={currentPage === 1} className="h-9 rounded-xl border border-slate-800 bg-slate-900/80 px-4 text-[13px] font-bold text-slate-200 transition-colors hover:border-slate-700 hover:bg-slate-800 disabled:opacity-40">Prev</button>
+            <span className="px-3 text-[12px] font-bold tabular-nums text-slate-400">{currentPage} / {totalPages}</span>
+            <button type="button" onClick={() => setCurrentPage((page) => Math.min(totalPages, page + 1))} disabled={currentPage === totalPages || totalItems === 0} className="h-9 rounded-xl border border-slate-800 bg-slate-900/80 px-4 text-[13px] font-bold text-slate-200 transition-colors hover:border-slate-700 hover:bg-slate-800 disabled:opacity-40">Next</button>
           </div>
         </div>
       </div>

--- a/frontend/src/app/services/api.ts
+++ b/frontend/src/app/services/api.ts
@@ -126,6 +126,7 @@ export interface UtteranceData {
   id: string;
   interactionId: string;
   speaker: string;
+  sequenceIndex?: number;
   text: string;
   startTime: number;
   endTime: number;
@@ -212,6 +213,70 @@ export interface LLMEvidenceCitation {
   utteranceIndex?: number | null;
 }
 
+export interface ExplainabilitySpan {
+  utteranceIndex?: number | null;
+  speaker?: "customer" | "agent" | "system" | "unknown";
+  quote: string;
+  timestamp?: string | null;
+  startSeconds?: number | null;
+  endSeconds?: number | null;
+}
+
+export interface ExplainabilityPolicyReference {
+  source: "policy" | "sop";
+  reference: string;
+  clause: string;
+  version?: string | null;
+  category?: string | null;
+  provenance?: string | null;
+}
+
+export interface TriggerAttribution {
+  attributionId: string;
+  family: "emotion" | "sop" | "policy";
+  triggerType: string;
+  title: string;
+  verdict:
+    | "Supported"
+    | "Partial Attempt"
+    | "Neutral"
+    | "Contradiction"
+    | "Cross-Modal Mismatch"
+    | "No Trigger"
+    | "Insufficient Evidence";
+  confidence?: number | null;
+  evidenceSpan?: ExplainabilitySpan | null;
+  policyReference?: ExplainabilityPolicyReference | null;
+  reasoning: string;
+  evidenceChain: string[];
+  supportingQuotes: string[];
+}
+
+export interface ClaimProvenance {
+  claimId: string;
+  claimText: string;
+  claimSpan?: ExplainabilitySpan | null;
+  retrievedPolicy?: ExplainabilityPolicyReference | null;
+  semanticSimilarity?: number | null;
+  nliVerdict:
+    | "Supported"
+    | "Partial Attempt"
+    | "Neutral"
+    | "Contradiction"
+    | "Cross-Modal Mismatch"
+    | "No Trigger"
+    | "Insufficient Evidence";
+  confidence?: number | null;
+  reasoning: string;
+  provenance: string;
+  supportingQuotes: string[];
+}
+
+export interface EvidenceAnchoredExplainability {
+  triggerAttributions: TriggerAttribution[];
+  claimProvenance: ClaimProvenance[];
+}
+
 export interface LLMEmotionShift {
   isDissonanceDetected: boolean;
   dissonanceType: string;
@@ -222,6 +287,7 @@ export interface LLMEmotionShift {
   evidenceQuotes: string[];
   citations: LLMEvidenceCitation[];
   insufficientEvidence?: boolean;
+  confidenceScore?: number | null;
 }
 
 export interface LLMProcessAdherence {
@@ -233,6 +299,7 @@ export interface LLMProcessAdherence {
   evidenceQuotes: string[];
   citations: LLMEvidenceCitation[];
   insufficientEvidence?: boolean;
+  confidenceScore?: number | null;
 }
 
 export interface LLMNliPolicy {
@@ -245,6 +312,8 @@ export interface LLMNliPolicy {
   policyCategory?: string | null;
   conflictResolutionApplied?: boolean;
   insufficientEvidence?: boolean;
+  confidenceScore?: number | null;
+  policyAlignmentScore?: number | null;
 }
 
 export interface LLMTriggerReport {
@@ -256,6 +325,7 @@ export interface LLMTriggerReport {
   emotionShift?: LLMEmotionShift;
   processAdherence?: LLMProcessAdherence;
   nliPolicy?: LLMNliPolicy;
+  explainability?: EvidenceAnchoredExplainability;
   derived?: {
     customerText: string;
     acousticEmotion: string;
@@ -271,6 +341,7 @@ export interface EmotionTriggerReport {
   forcedRerun?: boolean;
   interactionId?: string;
   emotionShift?: LLMEmotionShift;
+  explainability?: EvidenceAnchoredExplainability;
   derived?: {
     customerText: string;
     acousticEmotion: string;
@@ -287,6 +358,7 @@ export interface RagComplianceReport {
   interactionId?: string;
   processAdherence?: LLMProcessAdherence;
   nliPolicy?: LLMNliPolicy;
+  explainability?: EvidenceAnchoredExplainability;
   policyViolations?: PolicyViolationData[];
 }
 

--- a/frontend/src/tests/LLMTriggerSections.test.tsx
+++ b/frontend/src/tests/LLMTriggerSections.test.tsx
@@ -65,6 +65,61 @@ vi.mock("../app/services/api", () => {
         evidenceQuotes: [],
         citations: [],
       },
+      explainability: {
+        triggerAttributions: [
+          {
+            attributionId: "sop-1",
+            family: "sop",
+            triggerType: "SOP Violation",
+            title: "Confirm account details",
+            verdict: "Contradiction",
+            confidence: 0.73,
+            evidenceSpan: {
+              utteranceIndex: 0,
+              speaker: "agent",
+              quote: "Let me look up the billing record.",
+              timestamp: "00:15",
+              startSeconds: 15,
+              endSeconds: 18,
+            },
+            policyReference: {
+              source: "sop",
+              reference: "Billing SOP",
+              clause: "Verify account and charge details before lookup.",
+              provenance: "SOP retrieval context",
+            },
+            reasoning: "The agent moved to account lookup before verification.",
+            evidenceChain: ["Expected SOP step: Confirm account details."],
+            supportingQuotes: ["Let me look up the billing record."],
+          },
+        ],
+        claimProvenance: [
+          {
+            claimId: "claim-1",
+            claimText: "The refund will clear today.",
+            claimSpan: {
+              utteranceIndex: 0,
+              speaker: "agent",
+              quote: "The refund will clear today.",
+              timestamp: "00:15",
+              startSeconds: 15,
+              endSeconds: 18,
+            },
+            retrievedPolicy: {
+              source: "policy",
+              reference: "Refund Policy",
+              clause: "Standard refunds take 3-5 business days.",
+              provenance: "Refund Timelines",
+            },
+            semanticSimilarity: 0.79,
+            nliVerdict: "Contradiction",
+            confidence: 0.81,
+            reasoning: "The promise contradicts the retrieved policy clause.",
+            provenance: "Refund Policy • Refund Timelines",
+            supportingQuotes: ["The refund will clear today."],
+          },
+        ],
+      },
     },
   };
 
@@ -86,7 +141,8 @@ describe("LLM trigger sections", () => {
 
     expect(await screen.findByText("Emotion Trigger Reasoning")).toBeInTheDocument();
     expect(screen.getByText(/billing_issue/)).toBeInTheDocument();
-    expect(screen.getByText(/Contradiction/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Contradiction/).length).toBeGreaterThan(0);
+    expect(screen.getByText("Evidence-Anchored Explainability")).toBeInTheDocument();
   });
 
   it("renders agent llm coaching section", async () => {
@@ -100,6 +156,6 @@ describe("LLM trigger sections", () => {
 
     expect(await screen.findByText("LLM Coaching Insights")).toBeInTheDocument();
     expect(screen.getByText("billing_issue")).toBeInTheDocument();
-    expect(screen.getByText("Contradiction")).toBeInTheDocument();
+    expect(screen.getAllByText("Contradiction").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/tests/SessionDetail.test.tsx
+++ b/frontend/src/tests/SessionDetail.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { SessionDetail } from '../app/components/manager/SessionDetail'
 import { MemoryRouter, Routes, Route } from 'react-router'
@@ -95,6 +95,83 @@ const detail = {
             evidenceQuotes: [],
             citations: [],
         },
+        explainability: {
+            triggerAttributions: [
+                {
+                    attributionId: 'emotion-1',
+                    family: 'emotion',
+                    triggerType: 'Acoustic-Transcript Dissonance',
+                    title: 'Sarcasm',
+                    verdict: 'Cross-Modal Mismatch',
+                    confidence: 0.82,
+                    evidenceSpan: {
+                        utteranceIndex: 1,
+                        speaker: 'customer',
+                        quote: 'This has been going on for days and I am frustrated.',
+                        timestamp: '00:04',
+                        startSeconds: 4,
+                        endSeconds: 8,
+                    },
+                    reasoning: 'Customer wording and fused emotion disagree.',
+                    evidenceChain: [
+                        'Acoustic emotion signal resolved to frustrated.',
+                        'Transcript span used for review: This has been going on for days and I am frustrated.',
+                    ],
+                    supportingQuotes: ['This has been going on for days and I am frustrated.'],
+                },
+                {
+                    attributionId: 'sop-1',
+                    family: 'sop',
+                    triggerType: 'SOP Violation',
+                    title: 'Confirm account details',
+                    verdict: 'Contradiction',
+                    confidence: 0.74,
+                    evidenceSpan: {
+                        utteranceIndex: 0,
+                        speaker: 'agent',
+                        quote: 'Hello, I can help with billing.',
+                        timestamp: '00:00',
+                        startSeconds: 0,
+                        endSeconds: 3,
+                    },
+                    policyReference: {
+                        source: 'sop',
+                        reference: 'billing-issue SOP',
+                        clause: 'Verify account and charge details before lookup.',
+                        provenance: 'SOP retrieval context',
+                    },
+                    reasoning: 'Agent skipped verification before continuing.',
+                    evidenceChain: ['Expected SOP step: Confirm account details.'],
+                    supportingQuotes: ['Hello, I can help with billing.'],
+                },
+            ],
+            claimProvenance: [
+                {
+                    claimId: 'claim-1',
+                    claimText: 'Your refund will arrive within 24 hours.',
+                    claimSpan: {
+                        utteranceIndex: 0,
+                        speaker: 'agent',
+                        quote: 'Your refund will arrive within 24 hours.',
+                        timestamp: '00:00',
+                        startSeconds: 0,
+                        endSeconds: 3,
+                    },
+                    retrievedPolicy: {
+                        source: 'policy',
+                        reference: 'Refunds Policy v2.3',
+                        clause: 'Standard refunds take 3-5 business days.',
+                        provenance: 'Refund Timelines • v2.3',
+                    },
+                    semanticSimilarity: 0.81,
+                    nliVerdict: 'Contradiction',
+                    confidence: 0.8,
+                    reasoning: 'The promise contradicts the active refund timeline.',
+                    provenance: 'Refunds Policy v2.3 • Refund Timelines • v2.3',
+                    supportingQuotes: ['Your refund will arrive within 24 hours.'],
+                },
+            ],
+        },
     },
 }
 
@@ -125,7 +202,20 @@ describe('SessionDetail', () => {
         expect(screen.getByText(/Process Adherence/)).toBeInTheDocument()
         expect(screen.getByText(/Policy Inference/)).toBeInTheDocument()
         expect(screen.getByText(/billing_issue/)).toBeInTheDocument()
-        expect(screen.getByText(/Contradiction/)).toBeInTheDocument()
+        expect(screen.getAllByText(/Contradiction/).length).toBeGreaterThan(0)
+    })
+
+    it('renders evidence-anchored explainability cards', async () => {
+        getInteractionDetailMock.mockResolvedValue(detail)
+        renderWithId()
+
+        expect(await screen.findByText('Evidence-Anchored Explainability')).toBeInTheDocument()
+        expect(screen.getByText('Claim to evidence to verdict')).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: /Retrieval Provenance Scoring/i }))
+        expect(screen.getByText('Retrieval Provenance Scoring')).toBeInTheDocument()
+        expect(screen.getByText('Your refund will arrive within 24 hours.')).toBeInTheDocument()
+        expect(screen.getByText('Standard refunds take 3-5 business days.')).toBeInTheDocument()
     })
 
     it('normalizes non-canonical emotions instead of treating them as neutral', async () => {

--- a/services/rag/README.md
+++ b/services/rag/README.md
@@ -23,6 +23,7 @@ A robust Retrieval-Augmented Generation (RAG) system for policy document analysi
 - **Policy Compliance & Answer Scoring**: Built-in evaluators for both transcript compliance and answer correctness
 - **Detailed Logging**: All queries and evaluations are logged as JSON in `logs/`
 - **Evaluation Suite**: Automated scoring and reporting for compliance and answer accuracy
+- **Explainability Hooks**: Retrieval provenance can be surfaced to manager UI and API consumers
 
 ## Documentation
 
@@ -30,6 +31,7 @@ Team-facing RAG documentation is maintained in:
 
 1. `docs/rag/RAG_OVERVIEW.md`
 2. `docs/rag/INGESTION_PIPELINE.md`
+3. `docs/explainability/EVIDENCE_ANCHORED_EXPLAINABILITY_LAYER.md`
 
 ---
 

--- a/services/rag/config.py
+++ b/services/rag/config.py
@@ -79,7 +79,11 @@ class Settings(BaseSettings):
     """Application-wide settings with environment variable support."""
 
     model_config = SettingsConfigDict(
-        env_file=SERVICE_DIR / ".env",
+        env_file=(
+            SERVICE_DIR / ".env",
+            REPO_ROOT / ".env",
+            REPO_ROOT / "backend" / ".env",
+        ),
         env_file_encoding="utf-8",
         extra="ignore",
         env_nested_delimiter="__",

--- a/services/rag/evaluator.py
+++ b/services/rag/evaluator.py
@@ -22,8 +22,12 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-from config import settings
-from query_engine import RAGQueryEngine
+try:
+    from .config import settings
+    from .query_engine import RAGQueryEngine
+except ImportError:  # pragma: no cover - allows direct script/test imports
+    from config import settings
+    from query_engine import RAGQueryEngine
 
 
 # ── Result Models ─────────────────────────────────────────────────────────────

--- a/services/rag/ingest.py
+++ b/services/rag/ingest.py
@@ -31,7 +31,10 @@ from langchain_text_splitters import (
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, FieldCondition, Filter, FilterSelector, MatchValue, PointStruct, VectorParams
 
-from config import settings
+try:
+    from .config import settings
+except ImportError:  # pragma: no cover - allows direct script/test imports
+    from config import settings
 
 
 # ── Docling Singleton ─────────────────────────────────────────────────────────

--- a/services/rag/main.py
+++ b/services/rag/main.py
@@ -44,7 +44,10 @@ def _snapshot_documents(docs_dirs: list[Path]) -> dict[str, tuple[int, int]]:
 
 def cmd_ingest(args: argparse.Namespace) -> None:
     """Run document ingestion pipeline."""
-    from ingest import DocumentIngestionPipeline
+    try:
+        from .ingest import DocumentIngestionPipeline
+    except ImportError:  # pragma: no cover - direct script execution
+        from ingest import DocumentIngestionPipeline
 
     print("=" * 60)
     print("VocalMind Final RAG — Document Ingestion")
@@ -58,8 +61,12 @@ def cmd_ingest(args: argparse.Namespace) -> None:
 
 def cmd_watch(args: argparse.Namespace) -> None:
     """Keep the ingestion service alive and reprocess documents on change."""
-    from config import settings
-    from ingest import DocumentIngestionPipeline
+    try:
+        from .config import settings
+        from .ingest import DocumentIngestionPipeline
+    except ImportError:  # pragma: no cover - direct script execution
+        from config import settings
+        from ingest import DocumentIngestionPipeline
 
     print("=" * 60)
     print("VocalMind Final RAG — Watch Mode")
@@ -98,8 +105,12 @@ def cmd_watch(args: argparse.Namespace) -> None:
 
 def cmd_query(args: argparse.Namespace) -> None:
     """Execute a single query."""
-    from config import settings
-    from query_engine import RAGQueryEngine
+    try:
+        from .config import settings
+        from .query_engine import RAGQueryEngine
+    except ImportError:  # pragma: no cover - direct script execution
+        from config import settings
+        from query_engine import RAGQueryEngine
 
     engine = RAGQueryEngine()
 
@@ -121,7 +132,10 @@ def cmd_query(args: argparse.Namespace) -> None:
 
 def cmd_compliance(args: argparse.Namespace) -> None:
     """Run a policy compliance check."""
-    from evaluator import PolicyComplianceEvaluator
+    try:
+        from .evaluator import PolicyComplianceEvaluator
+    except ImportError:  # pragma: no cover - direct script execution
+        from evaluator import PolicyComplianceEvaluator
 
     print("=" * 60)
     print("VocalMind Final RAG — Policy Compliance Check")
@@ -150,7 +164,10 @@ def cmd_compliance(args: argparse.Namespace) -> None:
 
 def cmd_check_answer(args: argparse.Namespace) -> None:
     """Run an answer correctness check."""
-    from evaluator import AnswerCorrectnessEvaluator
+    try:
+        from .evaluator import AnswerCorrectnessEvaluator
+    except ImportError:  # pragma: no cover - direct script execution
+        from evaluator import AnswerCorrectnessEvaluator
 
     print("=" * 60)
     print("VocalMind Final RAG — Answer Correctness Check")
@@ -176,8 +193,12 @@ def cmd_check_answer(args: argparse.Namespace) -> None:
 
 def cmd_interactive(args: argparse.Namespace) -> None:
     """Interactive query session."""
-    from config import settings
-    from query_engine import RAGQueryEngine
+    try:
+        from .config import settings
+        from .query_engine import RAGQueryEngine
+    except ImportError:  # pragma: no cover - direct script execution
+        from config import settings
+        from query_engine import RAGQueryEngine
 
     print("=" * 60)
     print("VocalMind Final RAG — Interactive Mode")

--- a/services/rag/query_engine.py
+++ b/services/rag/query_engine.py
@@ -20,7 +20,10 @@ from llama_index.llms.groq import Groq as LlamaGroq
 from qdrant_client import QdrantClient
 from qdrant_client.models import ScoredPoint
 
-from config import settings
+try:
+    from .config import settings
+except ImportError:  # pragma: no cover - allows direct script/test imports
+    from config import settings
 
 
 class RAGQueryEngine:


### PR DESCRIPTION
## Description

This PR adds an evidence-anchored explainability layer across the LLM Trigger and RAG Compliance flows, improves Session Inspector / Session Detail UX, and fixes several scoring and retrieval issues that were making good calls look misleadingly bad.

Main changes:
- Added span-level trigger attribution for SOP, policy, and emotion findings
- Added claim-level retrieval provenance cards with policy chunk references, verdicts, and confidence
- Persisted LLM trigger/explainability results so opening Session Detail does not recompute them on every inspect
- Cleared and regenerated cached explainability on reprocess
- Improved scoring normalization and API score scaling from 0-1 storage to manager-facing percentages
- Reworked Session Detail layout and compacted evidence cards into grouped paged sections
- Added backend/frontend documentation for the Evidence-Anchored Explainability Layer
- Improved SOP/policy retrieval selection and cleaned raw parsed-doc formatting in evidence cards
- Added per-emotion-change trigger cards in addition to the overall emotion summary

## Why

Previously, the system returned session-level verdicts and scores without a clear evidence trail, and Session Detail could re-trigger expensive evaluation work on open. In some NexaLink benchmark samples, this also led to wrong SOP grounding, noisy evidence spans, and misleading UI output.

This PR makes results:
- traceable
- cached/persisted
- easier for managers to review
- closer to the intended benchmark behavior

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📚 Documentation
- [x] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 DevOps / CI

## Notes

Important implementation details:
- Session Detail now reuses saved explainability results instead of recomputing on each inspect
- Reprocess clears cached explainability and regenerates transcript, emotion events, scores, compliance, and evidence cards
- SOP retrieval now prefers vector/Qdrant retrieval when available and falls back to local parsed docs when needed
- Evidence card text is sanitized to avoid raw markdown / parsed-doc artifacts leaking into the UI

## Checklist

- [x] My code follows the project coding standards
- [x] I have run `make backend-lint` and `make frontend-build` or equivalent checks where applicable
- [x] I have added/updated tests if applicable
- [x] I have updated documentation if applicable
